### PR TITLE
Just fixed a small bug with the way DjangoConfigStorage handles missing values

### DIFF
--- a/src/django_assets/env.py
+++ b/src/django_assets/env.py
@@ -27,7 +27,10 @@ class DjangoConfigStorage(ConfigStorage):
         return hasattr(settings, self._transform_key(key))
 
     def __getitem__(self, key):
-        return getattr(settings, self._transform_key(key))
+        if self.__contains__(key):
+            return getattr(settings, self._transform_key(key))
+        else:
+            raise KeyError("Django settings doesn't define %s" % key)
 
     def __setitem__(self, key, value):
         setattr(settings, self._transform_key(key), value)


### PR DESCRIPTION
Here goes the fix, along with a braidead implementation of the project-level assets.py file. Mind you, I just wanted to create the pull request for the bugfix, not the other bit :)
