### PR TITLE
Django 1 2 quick: Template loader paths have changed

### DIFF
--- a/src/django_assets/loaders.py
+++ b/src/django_assets/loaders.py
@@ -27,9 +27,9 @@ def get_django_template_dirs():
     """Build a list of template directories based on configured loaders.
     """
     template_dirs = []
-    if 'django.template.loaders.filesystem.load_template_source' in settings.TEMPLATE_LOADERS:
+    if 'django.template.loaders.filesystem.load_template_source' in settings.TEMPLATE_LOADERS or 'django.template.loaders.filesystem.Loader' in settings.TEMPLATE_LOADERS:
         template_dirs.extend(settings.TEMPLATE_DIRS)
-    if 'django.template.loaders.app_directories.load_template_source' in settings.TEMPLATE_LOADERS:
+    if 'django.template.loaders.app_directories.load_template_source' in settings.TEMPLATE_LOADERS or 'django.template.loaders.app_directories.Loader' in settings.TEMPLATE_LOADERS:
         from django.template.loaders.app_directories import app_template_dirs
         template_dirs.extend(app_template_dirs)
     return template_dirs


### PR DESCRIPTION
Django 1.2 has moved to a callable style for it's template loaders, so the if statements for adding paths to search for the webassets tags no longer match.  I think this should work as a fix, but it feels like there should be something slightly more elegant.  

I've also failed to add anything in the way of test coverage.
