### PR TITLE
pop the correct item from sys.path in PythonLoader.__init__

### DIFF
--- a/src/webassets/loaders.py
+++ b/src/webassets/loaders.py
@@ -149,7 +149,7 @@ class PythonLoader(object):
             except ImportError, e:
                 raise LoaderError(e)
         finally:
-            sys.path.pop()
+            sys.path.pop(0)
 
     def load_bundles(self):
         """Load ``Bundle`` objects defined in the Python module.


### PR DESCRIPTION
PythonLoader's **init** adds the current directory to the beginning of sys.path, does some work, and then pops the _last_ entry from sys.path, thereby (in my case) breaking it. pop(0) is what you want to pop the first item from the list.
