### PR TITLE
Removed var from jst template namespace definition

### DIFF
--- a/src/webassets/filter/jst.py
+++ b/src/webassets/filter/jst.py
@@ -41,7 +41,7 @@ class JSTFilter(Filter):
         if not self._bare:
             out.write("(function(){\n    ")
 
-        out.write("var %s = %s || {};\n" % (self._namespace, self._namespace))
+        out.write("%s = %s || {};\n" % (self._namespace, self._namespace))
 
         if self._include_jst_script:
             out.write("%s\n" % _jst_script)


### PR DESCRIPTION
This is needed in order to be able to use nested namespaces with JST templates. For example, 'appname.templates'
