### PR TITLE
PyPy support

### DIFF
--- a/src/webassets/ext/jinja2.py
+++ b/src/webassets/ext/jinja2.py
@@ -42,7 +42,7 @@ class AssetsExtension(Extension):
 
         # parse the arguments
         first = True
-        while parser.stream.current.type is not 'block_end':
+        while parser.stream.current.type != 'block_end':
             if not first:
                 parser.stream.expect('comma')
             first = False


### PR DESCRIPTION
In PyPy, there is no string intering (yet), so the "is not" comparison would fail a generate a parse error.  Changing it to a string compare fixes the issue for Pypy1.5.
