### PR TITLE
Refactor bundle to allow override specific methods in subclass

### DIFF
--- a/src/webassets/merge.py
+++ b/src/webassets/merge.py
@@ -170,34 +170,6 @@ def apply_filters(hunk, filters, type, cache=None, no_cache_read=False,
     return MemoryHunk(content)
 
 
-def make_url(env, filename, expire=True):
-    """Return a output url, modified for expire header handling.
-
-    Set ``expire`` to ``False`` if you do not want the URL to
-    be modified for cache busting.
-    """
-    if expire:
-        path = env.abspath(filename)
-        if env.expire == 'querystring':
-            last_modified = os.stat(path).st_mtime
-            result = "%s?%d" % (filename, last_modified)
-        elif env.expire == 'filename':
-            last_modified = os.stat(path).st_mtime
-            name = filename.rsplit('.', 1)
-            if len(name) > 1:
-                result = "%s.%d.%s" % (name[0], last_modified, name[1])
-            else:
-                result = "%s.%d" % (name, last_modified)
-        elif not env.expire:
-            result = filename
-        else:
-            raise ValueError('Unknown value for ASSETS_EXPIRE option: %s' %
-                                 env.expire)
-    else:
-        result = filename
-    return env.absurl(result)
-
-
 def merge_filters(filters1, filters2):
     """Merge two filter lists into one.
 


### PR DESCRIPTION
With just few changes I am able to subclass Bundle in a way, that will allow to run it on Google App Engine. My AppEngineBundle for flask is here: https://gist.github.com/1307521 . Usage:
- You have to use AppEngineBundle instead of Bundle in your Flask app.py.
- You have to use manage.py assets rebuild/watch.
- Timestamps are stored in _webassets.py file in project root, because with dev_appserver there is no ability to write into files.

If you are interested to have AppEngineBundle in extensions I could create a separate pull request.
