### PR TITLE
Enable passing of additional arguments to UglifyJS

### DIFF
--- a/src/webassets/filter/uglifyjs.py
+++ b/src/webassets/filter/uglifyjs.py
@@ -1,11 +1,3 @@
-"""Minify Javascript using `UglifyJS <https://github.com/mishoo/UglifyJS/>`_.
-
-UglifyJS is an external tool written for NodeJS; this filter assumes that
-the ``uglifyjs`` executable is in the path. Otherwise, you may define
-a ``UGLIFYJS_BIN`` setting. Additional options may be passed to ``uglifyjs``
-by setting ``UGLIFYJS_EXTRA_ARGS``, which expects a list of strings.
-"""
-
 import subprocess
 from webassets.exceptions import FilterError
 from webassets.filter import Filter
@@ -15,6 +7,16 @@ __all__ = ('UglifyJSFilter',)
 
 
 class UglifyJSFilter(Filter):
+    """
+    Minify Javascript using `UglifyJS <https://github.com/mishoo/UglifyJS/>`_.
+
+    UglifyJS is an external tool written for NodeJS; this filter assumes that
+    the ``uglifyjs`` executable is in the path. Otherwise, you may define
+    a ``UGLIFYJS_BIN`` setting.
+
+    Additional options may be passed to ``uglifyjs`` using the setting
+    ``UGLIFYJS_EXTRA_ARGS``, which expects a list of strings.
+    """
 
     name = 'uglifyjs'
 


### PR DESCRIPTION
Hi! This simple patch adds support for passing command-line options to the `uglifyjs` binary, via a new `UGLIFY_EXTRA_ARGS` setting. I tried to code this consistently with the way arguments are handled in other filters.
