### PR TITLE
Fix reworked UglifyJSFilter docstring not being included in auto-generated docs

### DIFF
--- a/docs/builtin_filters.rst
+++ b/docs/builtin_filters.rst
@@ -36,7 +36,7 @@ Javascript compressors
 ``uglifyjs``
 ~~~~~~~~~~~~
 
-.. automodule:: webassets.filter.uglifyjs
+.. autoclass:: webassets.filter.uglifyjs.UglifyJSFilter
 
 
 ``jsmin``


### PR DESCRIPTION
Sorry, should have included this in my last pull request. Thanks again!
