### PR TITLE
Debug flag should be configurable in .yaml files.

### DIFF
--- a/src/webassets/loaders.py
+++ b/src/webassets/loaders.py
@@ -52,6 +52,7 @@ class YAMLLoader(object):
             bundles[key] = Bundle(
                 filters=data.get('filters', None),
                 output=data.get('output', None),
+                debug=data.get('debug', None),
                 *contents
             )
         return bundles


### PR DESCRIPTION
This one-line modification to YAMLLoader adds support for specifying debug flag in bundle definitions.
