### PR TITLE
Fix URL detection on Windows

### DIFF
--- a/src/webassets/bundle.py
+++ b/src/webassets/bundle.py
@@ -19,8 +19,10 @@ __all__ = ('Bundle', 'get_all_bundle_files',)
 
 
 def is_url(s):
-    return isinstance(s, str) and bool(urlparse.urlsplit(s).scheme)
-
+    if not isinstance(s, str):
+        return False
+    scheme = urlparse.urlsplit(s).scheme
+    return bool(scheme) and len(scheme) > 1
 
 class Bundle(object):
     """A bundle is the unit webassets uses to organize groups of


### PR DESCRIPTION
On windows, the paths for assets are expanded to something like "D:\foo\bar\myfile.css" and urlparse thinks that 'D' is the scheme, so all assets are incorrectly opened as URLs instead of files.

Add a check that the scheme isn't a single letter so windows drives are supported.
