### PR TITLE
Change __repr__ to use the actual class name to ensure it properly reflects subclasses

### DIFF
--- a/src/webassets/bundle.py
+++ b/src/webassets/bundle.py
@@ -60,7 +60,8 @@ class Bundle(object):
         self.extra_data = {}
 
     def __repr__(self):
-        return "<Bundle output=%s, filters=%s, contents=%s>" % (
+        return "<%s output=%s, filters=%s, contents=%s>" % (
+            self.__class__.__name__,
             self.output,
             self.filters,
             self.contents,


### PR DESCRIPTION
This tripped me up a bit when I was trying to debug a custom Bundle class. I spent a little while trying to figure out why my bundle appeared to get skipped somewhere along the way, when in fact it was just spitting out a hardcoded class name.

Thanks!
- Erik
