### PR TITLE
Use correct reference to `env` - `self.env` isn't actually set

### DIFF
--- a/src/webassets/script.py
+++ b/src/webassets/script.py
@@ -362,7 +362,7 @@ class GenericArgparseImplementation(object):
                 del args[name]
 
         # Run the selected command
-        cmd = CommandLineEnvironment(self.env, log)
+        cmd = CommandLineEnvironment(env, log)
         return cmd.invoke(ns.command, args)
 
     def main(self, argv):


### PR DESCRIPTION
Using the command line tools on HEAD don't work as the `environment` is always `None`. This change fixes the command line reference to the working environment.
