### PR TITLE
Enable setting HANDLEBARS_EXTRA_ARGS

### DIFF
--- a/src/webassets/filter/handlebars.py
+++ b/src/webassets/filter/handlebars.py
@@ -16,13 +16,18 @@ __all__ = ('HandlebarsFilter',)
 class HandlebarsFilter(Filter):
 
     name = 'handlebars'
-
-    def setup(self):
-        self.binary = self.get_config(
-            'HANDLEBARS_BIN', require=False) or 'handlebars'
+    options = {
+        'binary': 'HANDLEBARS_BIN',
+        'extra_args': 'HANDLEBARS_EXTRA_ARGS',
+    }
 
     def input(self, _in, out, source_path, output_path):
-        args = [self.binary, '-r', self.get_config('directory'), source_path]
+        args = [self.binary or 'handlebars']
+        if self.extra_args:
+            args.extend(self.extra_args)
+        else:
+            args.extend(['-r', self.get_config('directory')])
+        args.extend([source_path])
         proc = subprocess.Popen(
             args, stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,


### PR DESCRIPTION
The Handlebars filter uses the 'directory' config as root, but my project templates are in client/templates so it doesn't work.  This change enables settings HANDLEBARS_EXTRA_ARGS, while keeping the same defaults.

Guessing the shared root path automatically (like the JST filter) would be nice to have, but this change is simpler and fixes my problem (as well as exposing the other handlebars config options).
