### PR TITLE
Ticket #118: Add recursive bundle functionality to YAML Loader.

### DIFF
--- a/src/webassets/loaders.py
+++ b/src/webassets/loaders.py
@@ -68,6 +68,19 @@ class YAMLLoader(object):
             if data is None:
                 data = {}
             bundles[key] = self._get_bundle(data)
+
+        # now we need to recurse through the bundles and get any that
+        # are included in each other.
+        for bundle_name, bundle in bundles.items():
+            # copy contents
+            contents = list(bundle.contents)
+            for i, item in enumerate(bundle.contents):
+                if item in bundles:
+                    contents[i] = bundles[item]
+            # cast back to a tuple
+            contents = tuple(contents)
+            if contents != bundle.contents:
+                bundle.contents = contents
         return bundles
 
     def _open(self):

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -63,6 +63,26 @@ class TestYAML(object):
         assert len(nested_bundle.contents) == 4
         assert isinstance(nested_bundle.contents[2], Bundle)
 
+    def test_load_recursive_bundles(self):
+        bundles = self.loader("""
+        standard:
+            filters: cssmin,gzip
+            output: output.css
+            contents:
+                - file1
+                - file2
+        recursive:
+            output: recursive.css
+            filters: cssmin
+            contents:
+                - cssfile1
+                - standard
+                - cssfile2
+        """).load_bundles()
+        assert len(bundles) == 2
+        assert bundles['recursive'].contents[1].contents == bundles['standard'].contents
+        assert isinstance(bundles['recursive'].contents[1], Bundle)
+
     def test_empty_files(self):
         """YAML loader can deal with empty files.
         """


### PR DESCRIPTION
This looks for a string (e.g 'my_bundle') in the `contents` list of a
bundle. If that string has previously been made into a Bundle instance,
it replaces the string with that Bundle.
