### PR TITLE
datauri.py: fix duplicate url() when replacing url

### DIFF
--- a/src/webassets/filter/datauri.py
+++ b/src/webassets/filter/datauri.py
@@ -61,7 +61,7 @@ class CSSDataUriFilter(CSSUrlRewriter):
         try:
             if os.stat(filename).st_size <= (self.max_size or 2048):
                 data = b64encode(open(filename, 'rb').read())
-                return 'url("data:%s;base64,%s")' % (
+                return 'data:%s;base64,%s' % (
                     mimetypes.guess_type(filename)[0], data)
         except (OSError, IOError):
             # Ignore the file not existing.


### PR DESCRIPTION
When using the datauri filter, the URL in e.g. `url(image.png)` would get replaced with `url(url("data:image/png;base64, ..."))`.

This fixes duplicate `url()` and also removes unnecessary quotes.
