### PR TITLE
like uglifyjs, make coffeescript filter use output() and stdin

### DIFF
--- a/src/webassets/filter/coffeescript.py
+++ b/src/webassets/filter/coffeescript.py
@@ -28,29 +28,26 @@ class CoffeeScriptFilter(Filter):
         'no_bare': 'COFFEE_NO_BARE',
     }
 
-    def input(self, _in, out, source_path, output_path, **kw):
-        old_dir = os.getcwd()
-        os.chdir(os.path.dirname(source_path))
-        try:
-            binary = self.coffee_bin or self.coffee_deprecated or 'coffee'
-            if self.coffee_deprecated:
-                import warnings
-                warnings.warn(
-                    'The COFFEE_PATH option of the "coffeescript" '
-                    +'filter has been deprecated and will be removed.'
-                    +'Use COFFEE_BIN instead.', ImminentDeprecationWarning)
+    def output(self, _in, out, **kw):
+        binary = self.coffee_bin or self.coffee_deprecated or 'coffee'
+        if self.coffee_deprecated:
+            import warnings
+            warnings.warn(
+                'The COFFEE_PATH option of the "coffeescript" '
+                +'filter has been deprecated and will be removed.'
+                +'Use COFFEE_BIN instead.', ImminentDeprecationWarning)
 
-            args = "-p" + ("" if self.no_bare else 'b')
-            proc = subprocess.Popen([binary, args, source_path],
-                                    stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE)
-            stdout, stderr = proc.communicate()
-            if proc.returncode != 0:
-                raise FilterError(('coffeescript: subprocess had error: stderr=%s, '+
-                                   'stdout=%s, returncode=%s') % (
-                                                stderr, stdout, proc.returncode))
-            elif stderr:
-                print "coffeescript filter has warnings:", stderr
-            out.write(stdout)
-        finally:
-            os.chdir(old_dir)
+        args = "-sp" + ("" if self.no_bare else 'b')
+        proc = subprocess.Popen([binary, args],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE)
+        stdout, stderr = proc.communicate(_in.read())
+        if proc.returncode != 0:
+            raise FilterError(('coffeescript: subprocess had error: stderr=%s, '+
+                               'stdout=%s, returncode=%s') % (
+                stderr, stdout, proc.returncode))
+        elif stderr:
+            print "coffeescript filter has warnings:", stderr
+        out.write(stdout)
+    

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -377,7 +377,7 @@ class TestCoffeeScript(TempEnvironmentHelper):
     def test_default_options(self):
         self.create_files({'in': "alert \"I knew it!\" if elvis?"})
         self.mkbundle('in', filters='coffeescript', output='out.js').build()
-        assert self.get('out.js') == """if (typeof elvis !== "undefined" && elvis !== null) alert("I knew it!");\n"""
+        assert self.get('out.js') == """if (typeof elvis !== "undefined" && elvis !== null) {\n  alert("I knew it!");\n}\n"""
 
     def test_bare_option(self):
         self.env.config['COFFEE_NO_BARE'] = True


### PR DESCRIPTION
https://github.com/jashkenas/coffee-script/issues/2001 makes coffeescript pipable, use that.  This approach is better because:
- Coffeescript filter now doesn't change directory so relative bin path works as other filter
- no_bare more usefull when you have serveral coffeescript, because all file now wrapped together in one coffeescript namespace

I also change the expected output in coffeescript test. Dunno, but my coffeescript (1.3.1) output differs in whitespace 
