### PR TITLE
Change to less filter to use 'output' instead of 'open'

### DIFF
--- a/src/webassets/filter/less.py
+++ b/src/webassets/filter/less.py
@@ -16,13 +16,14 @@ class LessFilter(Filter):
         'less': ('binary', 'LESS_BIN')
     }
 
-    def open(self, out, source_path, **kw):
-        proc = subprocess.Popen(
-            [self.less or 'lessc', source_path],
-            stdout = subprocess.PIPE,
-            stderr = subprocess.PIPE
-        )
-        stdout, stderr = proc.communicate()
+    def output(self, _in, out, **kw):
+        binary = self.less or 'lessc'
+        args = '-'
+        proc = subprocess.Popen([binary, args],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE)
+        stdout, stderr = proc.communicate(_in.read())
 
         # At the moment (2011-12-09), there's a bug in the current version of
         # Less that always prints an error to stdout so the returncode is the


### PR DESCRIPTION
I noticed an issue where the less filter would not notice when changes were made to the original source file. This made using webassets+less cumbersome for local development, to say the least. I believe this is because for 'open' filters, cache.py only uses the filename as the key, not the contents of the file itself.

To be fair, I don't entirely understand all the bits and pieces involved, so I may be missing something. Regardless, the most straightforward way I could find to fix this is to update the less filter to use 'output' instead of 'open'. This is based on a somewhat-poorly documented command line switch to lessc that does not seem to have been available at the time the less filter was created: https://github.com/cloudhead/less.js/commit/f62b311aa21366c603a7fa8f726f767770776069
