### PR TITLE
Add config/config_file options to Compass filter

### DIFF
--- a/src/webassets/filter/compass.py
+++ b/src/webassets/filter/compass.py
@@ -157,7 +157,7 @@ class Compass(Filter):
                 http_stylesheets_dir='',
                 http_fonts_dir='',
                 http_javascripts_dir='',
-                images_dir=self.env.directory,
+                images_dir='',
             )
             # Update with the custom config dictionary, if any.
             if self.config:


### PR DESCRIPTION
See issues #36 and #125. I took a slightly different route than the solutions previously discussed; this is working for me (so far!) but I'm happy to alter the implementation as you see fit, so long as I can influence the temporary config.rb.

I moved the default configs out of the triple-quoted-string and into a thin dict wrapper. The wrapper just adds a to_string method that emits `key = "value"`, but that allows me to use `dict.update` to implement the `COMPASS_CONFIG` option. I also added a `COMPASS_CONFIG_FILE` option, since it might be easier for some folks transitioning from a more standard Compass environment.

I also added a `project_path` (set to `env.directory`) to the default config dict, which makes setting `images_dir` and so forth easier. As an example, here's the config I'm using now which allows me to use Compass's automatic sprite generation:

``` python
COMPASS_CONFIG = dict(
    images_dir='images/v2',
    http_images_path='/media/images/v2',
    generated_images_dir='gen',
    http_generated_images_path='/media/gen',
)
```
