### PR TITLE
Fix bug that prevented passing list of strings as options to compass.

### DIFF
--- a/src/webassets/filter/compass.py
+++ b/src/webassets/filter/compass.py
@@ -29,6 +29,7 @@ See:
 import os, subprocess
 from os import path
 import tempfile
+import types
 import shutil
 
 from webassets.exceptions import FilterError
@@ -42,7 +43,13 @@ class CompassConfig(dict):
     """A trivial dict wrapper that can generate a Compass config file."""
 
     def to_string(self):
-        return '\n'.join(['%s = "%s"' % (k, v) for k, v in self.items()])
+        def string_rep(val):
+            """ Determine the correct string rep for the config file """
+            if type(val) == types.ListType:
+                return str(val)
+            else:
+                return '"%s"' % val
+        return '\n'.join(['%s = %s' % (k, string_rep(v)) for k, v in self.items()])
 
 
 class Compass(Filter):


### PR DESCRIPTION
This was needed to pass the configuration param additional_import_paths through to compass.
Before this change, it would create a configuration file that looked like this:

```
additional_import_paths = "['/path/to/sass']"
```

Now it creates

```
additional_import_paths = ['/path/to/sass']
```

Note: There may still be other problems lurking related to non-string options being passed into the call to compass.  I think the best solution long term would be to add back the ability to pass in a ruby configuration file that was added by zakj here: miracle2k/webassets#153

 This would allow all normal options to work correctly and would also allow users to require other ruby modules and add new methods.
