### PR TITLE
Adding a Jinja2 Filter

### DIFF
--- a/src/webassets/filter/jinja2.py
+++ b/src/webassets/filter/jinja2.py
@@ -1,0 +1,28 @@
+from __future__ import absolute_import
+from webassets.filter import Filter
+
+
+__all__ = ('Jinja2',)
+
+
+class Jinja2(Filter):
+    """Process a file through the Jinja2 templating engine.
+
+    Requires the ``jinja2`` package (https://github.com/mitsuhiko/jinja2).
+    """
+
+    name = 'jinja2'
+    options = {
+        'context': 'JINJA2_CONTEXT',
+    }
+
+    def setup(self):
+        try:
+            import jinja2
+        except ImportError:
+            raise EnvironmentError('The "jinja2" package is not installed.')
+        else:
+            self.jinja2 = jinja2
+
+    def output(self, _in, out, **kw):
+        out.write(self.jinja2.Template(_in.read()).render(self.context or {}))

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -582,6 +582,23 @@ class TestCoffeeScript(TempEnvironmentHelper):
         assert self.get('out.js') == 'this.a = 1;\n'
 
 
+class TestJinja2(TempEnvironmentHelper):
+
+    def setup(self):
+        TempEnvironmentHelper.setup(self)
+
+    def test_default_options(self):
+        self.create_files({'in': """Hi there, {{ name }}!"""})
+        self.mkbundle('in', filters='jinja2', output='out.template').build()
+        assert self.get('out.template') == """Hi there, !"""
+
+    def test_bare_option(self):
+        self.env.config['JINJA2_CONTEXT'] = {'name': 'Randall'}
+        self.create_files({'in': """Hi there, {{ name }}!"""})
+        self.mkbundle('in', filters='jinja2', output='out.template').build()
+        assert self.get('out.template') == """Hi there, Randall!"""
+
+
 class TestClosure(TempEnvironmentHelper):
 
     default_files = {


### PR DESCRIPTION
This filter basically runs a file through the Jinja2 templateing engine,
allowing you to specify a dictionary to be used as a context. This way, it can
be easily extended to work with Flask, or any other framework that passes
context variables by default.
