### PR TITLE
Store version manifest as JSON

### DIFF
--- a/src/webassets/version.py
+++ b/src/webassets/version.py
@@ -6,7 +6,11 @@ from __future__ import with_statement
 
 import os
 import pickle
-import json
+
+try:
+    import json
+except ImportError:
+    import simplejson as json
 
 from webassets.bundle import has_placeholder, is_url, get_all_bundle_files
 from webassets.merge import FileHunk


### PR DESCRIPTION
Using JSON to store version information allows for greater interoperability between **webassets** and other non-Pythonic tools (e.g. Node.js/Express).
