### PR TITLE
Fixed a weird unicode character in clevercss.py filter

### DIFF
--- a/src/webassets/filter/clevercss.py
+++ b/src/webassets/filter/clevercss.py
@@ -1,4 +1,4 @@
-﻿from __future__ import absolute_import
+from __future__ import absolute_import
 from webassets.filter import Filter
 
 


### PR DESCRIPTION
The first char in clevercss.py filter is <U+FEFF>, which doesn't show up in vim or other editors.
Can view it in less and can edit it using nano.

This was throwing up UnicodeDecodeErrors when running nosetests with html output for coverage.
