### PR TITLE
Docs: Added json:{path} to the list of valid manifest values.

### DIFF
--- a/src/webassets/env.py
+++ b/src/webassets/env.py
@@ -558,6 +558,9 @@ class BaseEnvironment(object):
           path is given, the manifest will be stored as
           ``.webassets-manifest`` in ``Environment.directory``.
 
+      ``"json:{path}"``
+         Same as "file:{path}", but uses JSON to store the information.
+
       ``False``, ``None``
           No manifest is used.
 


### PR DESCRIPTION
The feature has been there for some time now, but information on it was not included in the documentation.
