### PR TITLE
Update Stylus filter with include paths

### DIFF
--- a/src/webassets/filter/stylus.py
+++ b/src/webassets/filter/stylus.py
@@ -1,3 +1,4 @@
+import os
 from webassets.filter import ExternalTool, option
 
 
@@ -24,6 +25,9 @@ class Stylus(ExternalTool):
 
     STYLUS_EXTRA_ARGS
         A Python list of any additional command-line arguments.
+        
+    STYLUS_EXTRA_PATHS
+        A Python list of any additional import paths.
     """
 
     name = 'stylus'
@@ -31,11 +35,16 @@ class Stylus(ExternalTool):
         'stylus': 'STYLUS_BIN',
         'plugins': option('STYLUS_PLUGINS', type=list),
         'extra_args': option('STYLUS_EXTRA_ARGS', type=list),
+        'extra_paths': option('STYLUS_EXTRA_PATHS', type=list),
     }
     max_debug_level = None
 
     def input(self, _in, out, **kwargs):
         args = [self.stylus or 'stylus']
+        source_dir = os.path.dirname(kwargs['source_path'])
+        paths = [source_dir] + (self.extra_paths or [])
+        for path in paths:
+            args.extend(('--include', path))
         for plugin in self.plugins or []:
             args.extend(('--use', plugin))
         if self.extra_args:


### PR DESCRIPTION
Since the Stylus filter works with stdin, the compiler doesn't know the source directory, and thus can't resolve any imports. This adds the source directory to the include path using the `--include` option, and also adds the `STYLUS_EXTRA_PATHS` option to configure any extra include paths.
