### PR TITLE
Make BaseEnvironment always evaluate to True in a boolean context

### DIFF
--- a/src/webassets/env.py
+++ b/src/webassets/env.py
@@ -377,6 +377,9 @@ class BaseEnvironment(object):
     def __len__(self):
         return len(self._named_bundles) + len(self._anon_bundles)
 
+    def __nonzero__(self):
+        return True
+
     def register(self, name, *args, **kwargs):
         """Register a :class:`Bundle` with the given ``name``.
 

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -89,6 +89,12 @@ class TestEnvApi(object):
         assert 'foo' in self.m
         assert not 'bar' in self.m
 
+    def test_bool_evaluation(self):
+        """Test that environment evaluates to True in a boolean context.
+        """
+        env = Environment()
+        assert env
+
     def test_url_and_directory(self):
         """The url and directory options are a bit special, because they
         are so essential.


### PR DESCRIPTION
I found a bit confusing that environment without bundles evaluates to `False`.

For example, when environment passed to the function as keyword argument, I must explicitly check whether it is `None` or not:
https://github.com/aromanovich/carcade/blob/master/carcade/environments.py#L56
