### PR TITLE
Allow use of webassets in .pyc-only deployments

### DIFF
--- a/src/webassets/filter/__init__.py
+++ b/src/webassets/filter/__init__.py
@@ -615,7 +615,7 @@ def unique_modules(directory):
     yields each entry as it is encountered
     """
     found = {}
-    for entry in os.listdir(directory):
+    for entry in sorted(os.listdir(directory)):
         if entry.startswith('_'):
             continue 
         module = is_module(entry)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -546,7 +546,13 @@ class TestBuiltinFilters(TempEnvironmentHelper):
     def test_find_pyc_files( self ):
         self.create_files({'test.pyc':'testing', 'test.py':'blue', 'boo.pyc':'boo'})
         modules = list( unique_modules(self.tempdir))
-        assert modules == ['test','boo'],modules
+        assert modules == ['boo','test'],modules
+    
+    def test_find_packages( self ):
+        self.create_files({'moo/__init__.pyc':'testing','voo/__init__.py':'testing'})
+        modules = list( unique_modules(self.tempdir))
+        assert modules == ['moo','voo'],modules
+        
 
 class TestCSSPrefixer(TempEnvironmentHelper):
 


### PR DESCRIPTION
Our projects are deployed in pyc-only environments, so the webassets filter plugins fail to find the builtin filters.  This (fairly small) change allows the filter plugins to be .py, .pyc or .so files.
