### PR TITLE
Enable LESS source maps generation if desired

### DIFF
--- a/src/webassets/filter/less.py
+++ b/src/webassets/filter/less.py
@@ -90,5 +90,4 @@ class Less(ExternalTool):
             cmd = [self.less or 'lessc', '-']
             if self.line_numbers:
                 cmd.insert(-1, '--line-numbers=%s' % self.line_numbers)
-            print cmd
             self.subprocess(cmd, out, in_)


### PR DESCRIPTION
With lessc v1.3.3 it is possible to generate SASS compatible source maps to ease the debugging sessions. The provided less.py filter does not accept extra parameters to tune the compiler.

I changed the less.py filter to give the ability to turn on the feature if desired using a `LESS_LINE_NUMBERS` option. It maps to the `--line-numbers` option of lessc, so as of version 1.3.3 it's possibile to use as values `comment` or `mediaquery` (the latter is the one needed to generate SASS compatible source maps).

The option is, well, optional and if a wrong value is provided nothing bad happens, the lessc compiler will just ignore it.
