### PR TITLE
Fix #212 UglifyJS filter EOF error when accepting data from STDIN

### DIFF
--- a/src/webassets/filter/uglifyjs.py
+++ b/src/webassets/filter/uglifyjs.py
@@ -23,7 +23,7 @@ class UglifyJS(ExternalTool):
     }
 
     def output(self, _in, out, **kw):
-        args = [self.binary or 'uglifyjs']
+        args = [self.binary or 'uglifyjs', '{input}', '--output', '{output}']
         if self.extra_args:
             args.extend(self.extra_args)
         self.subprocess(args, out, _in)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -472,7 +472,7 @@ class TestBuiltinFilters(TempEnvironmentHelper):
         if not find_executable('uglifyjs'):
             raise SkipTest()
         self.mkbundle('foo.js', filters='uglifyjs', output='out.js').build()
-        assert self.get('out.js') == 'function foo(a){var b;document.write(a)};'
+        assert self.get('out.js') == 'function foo(bar){var dummy;document.write(bar)}'
 
     def test_less_ruby(self):
         # TODO: Currently no way to differentiate the ruby lessc from the


### PR DESCRIPTION
This fix only works for uglifyjs >= 2.0 since it's changed its argument order. Let me know if you need to make it work for uglifyjs < 2.0 too.
