### PR TITLE
Google Closure Stylesheets filter(s) (#129)

### DIFF
--- a/src/webassets/filter/closure_stylesheets.py
+++ b/src/webassets/filter/closure_stylesheets.py
@@ -1,0 +1,50 @@
+""" Compile and Minify CSS with `Google Closure Stylesheets
+<http://code.google.com/p/closure-stylesheets/>`_.
+
+Google Closure Templates is an external tool written in Java, which needs
+to be obtained separately.
+
+You must define a ``CLOSURE_STYLESHEETS_PATH`` setting that
+points to the ``.jar`` file. Otherwise, an environment variable by
+the same name is tried. The filter will also look for a ``JAVA_HOME``
+environment variable to run the ``.jar`` file, or will otherwise
+assume that ``java`` is on the system path.
+"""
+
+from webassets.filter import JavaTool
+
+
+__all__ = ['ClosureStylesheetsCompiler', 'ClosureStylesheetsMinifier']
+
+
+class ClosureStylesheetsBase(JavaTool):
+
+    def setup(self):
+        super(ClosureStylesheetsBase, self).setup()
+        try:
+            self.jar = self.get_config('CLOSURE_STYLESHEETS_PATH',
+                    what='Google Closure Stylesheets tool')
+        except EnvironmentError:
+            raise EnvironmentError(
+                "\nGoogle Closure Stylesheets jar can't be found."
+                "\nPlease provide a CLOSURE_STYLESHEETS_PATH setting "
+                "or an environment variable with the full path to "
+                "the Google Closure Stylesheets jar."
+            )
+
+    def output(self, _in, out, **kw):
+        params = []
+        if self.mode != 'minify':
+            params.append('--pretty-print')
+        self.subprocess(
+            params + ['{input}'], out, _in)
+
+
+class ClosureStylesheetsCompiler(ClosureStylesheetsBase):
+    name = 'closure_stylesheets_compiler'
+    mode = 'compile'
+
+
+class ClosureStylesheetsMinifier(ClosureStylesheetsBase):
+    name = 'closure_stylesheets_minifier'
+    mode = 'minify'

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1123,3 +1123,29 @@ class TestTypeScript(TempEnvironmentHelper):
     def test(self):
         self.mkbundle('foo.ts', filters='typescript', output='out.js').build()
         assert self.get("out.js") == """var X = (function () {\r\n    function X() { }\r\n    return X;\r\n})();\r\n"""
+
+
+class TestClosureStylesheets(TempEnvironmentHelper):
+
+    default_files = {
+        'test.css': """
+        @def COLOR red;
+        p {
+            color: COLOR;
+        }
+        """
+    }
+
+    def setup(self):
+        if not 'CLOSURE_STYLESHEETS_PATH' in os.environ:
+            raise SkipTest()
+        TempEnvironmentHelper.setup(self)
+        
+    def test_compiler(self):
+        self.mkbundle('test.css', filters = 'closure_stylesheets_compiler', output = 'output.css').build()
+        assert 'color: red' in self.get('output.css')
+        
+    def test_minifier(self):
+        self.mkbundle('test.css', filters = 'closure_stylesheets_minifier', output = 'output.css').build()
+        assert self.get('output.css') == 'p{color:red}'
+        


### PR DESCRIPTION
This change adds support for the [Google Closure Stylesheets](http://code.google.com/p/closure-stylesheets/).

I followed reasoning in #129, i.e. created two separate filters for two major features of GCS.
