### PR TITLE
Document the fact that "depends" disables caching

### DIFF
--- a/docs/bundles.rst
+++ b/docs/bundles.rst
@@ -39,6 +39,10 @@ arguments:
   of a SCSS ``@import`` clause. Changes detected to one or multiple files
   whose name are specified by this keyword will recreate the bundle.
 
+  .. warning::
+    Bundles that use ``depends`` are never cached. Using ``depends`` in
+    production without setting ``auto_build=False`` is probably a bad idea.
+
 
 Nested bundles
 --------------


### PR DESCRIPTION
This bit me until I found the relevant comment in the code.

I think the workaround I suggested (use `depends` conditionally; with it when debugging, without it when deploying) is good enough so this isn't too big a problem - but IMHO it must be clearly documented.
