### PR TITLE
Making the CompassConfig class work with more ruby types

### DIFF
--- a/src/webassets/filter/compass.py
+++ b/src/webassets/filter/compass.py
@@ -26,11 +26,11 @@ See:
     http://groups.google.com/group/compass-users/browse_thread/thread/daf55acda03656d1
 """
 
-import os, subprocess
+import os
 from os import path
 import tempfile
-import types
 import shutil
+import subprocess
 
 from webassets.exceptions import FilterError
 from webassets.filter import Filter, option
@@ -45,10 +45,19 @@ class CompassConfig(dict):
     def to_string(self):
         def string_rep(val):
             """ Determine the correct string rep for the config file """
-            if type(val) == types.ListType:
+            if isinstance(val, bool):
+                # True -> true and False -> false
+                return str(val).lower()
+            elif isinstance(val, basestring) and val.startswith(':'):
+                # ruby symbols, like :nested, used for "output_style"
                 return str(val)
-            else:
-                return '"%s"' % val
+            elif isinstance(val, dict):
+                # ruby hashes, for "sass_options" for example
+                return '{%s}' % ', '.join("'%s' => '%s'" % i for i in val.items())
+            elif isinstance(val, tuple):
+                val = list(val)
+            # works fine with strings and lists
+            return repr(val)
         return '\n'.join(['%s = %s' % (k, string_rep(v)) for k, v in self.items()])
 
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -12,6 +12,7 @@ from webassets import Environment
 from webassets.exceptions import FilterError
 from webassets.filter import (
     Filter, ExternalTool, get_filter, register_filter)
+from webassets.filter.compass import CompassConfig
 from helpers import TempEnvironmentHelper
 
 # Sometimes testing filter output can be hard if they generate
@@ -935,6 +936,44 @@ class TestCompass(TempEnvironmentHelper):
         self.mkbundle('imguri.scss', filters='compass', output='out.css').build()
         assert doctest_match("""/* ... */\nh1 {\n  background: url('http://assets.host.com/the-images/test.png');\n}\n""", self.get('out.css'))
 
+
+class TestCompassConfig(object):
+
+    config = {
+        'http_path': '/',
+        'relative_assets': True,
+        'output_style': ':nested',
+        'sprite_load_path': [
+            'static/img',
+        ],
+        'additional_import_paths': (
+            'static/sass',
+        ),
+        'sass_options': {
+            'k': 'v'
+        }
+    }
+
+    def setup(self):
+        self.compass_config = CompassConfig(self.config).to_string()
+
+    def test_string_value(self):
+        assert "http_path = '/'" in self.compass_config
+
+    def test_boolean_value(self):
+        assert "relative_assets = true" in self.compass_config
+
+    def test_symbol_value(self):
+        assert 'output_style = :nested' in self.compass_config
+
+    def test_list_value(self):
+        assert "sprite_load_path = ['static/img']" in self.compass_config
+
+    def test_tuple_value(self):
+        assert "additional_import_paths = ['static/sass']" in self.compass_config
+
+    def test_dict_value(self):
+        assert "sass_options = {'k' => 'v'}" in self.compass_config
 
 class TestJST(TempEnvironmentHelper):
 


### PR DESCRIPTION
the CompassConfig class used to work with string and list types
but not with hashes, boolean and symbols types.
The options and possible value types can be seen here http://compass-style.org/help/tutorials/configuration-reference/
