### PR TITLE
Support multiple arguments for less binary

### DIFF
--- a/src/webassets/filter/__init__.py
+++ b/src/webassets/filter/__init__.py
@@ -502,6 +502,32 @@ class ExternalTool(Filter):
             if input_file.created:
                 os.unlink(input_file.filename)
 
+    @classmethod
+    def parse_binary(cls, string):
+        r"""
+        Parse a string for a binary (executable). Allow multiple arguments
+        to indicate the binary (as parsed by shlex).
+
+        Return a list of arguments suitable for passing to subprocess
+        functions.
+
+        >>> ExternalTool.parse_binary('/usr/bin/lessc')
+        ['/usr/bin/lessc']
+
+        >>> ExternalTool.parse_binary('node node_modules/bin/lessc')
+        ['node', 'node_modules/bin/lessc']
+
+        >>> ExternalTool.parse_binary('"binary with spaces"')
+        ['binary with spaces']
+
+        >>> ExternalTool.parse_binary(r'binary\ with\ spaces')
+        ['binary with spaces']
+
+        >>> ExternalTool.parse_binary('')
+        []
+        """
+        return shlex.split(string)
+
 
 class JavaTool(ExternalTool):
     """Helper class for filters which are implemented as Java ARchives (JARs).

--- a/src/webassets/filter/__init__.py
+++ b/src/webassets/filter/__init__.py
@@ -67,7 +67,7 @@ class option(tuple):
     """
     def __new__(cls, initarg, configvar=None, type=None):
         # If only one argument given, it is the configvar
-        if configvar is None:  
+        if configvar is None:
             configvar = initarg
             initarg = None
         return tuple.__new__(cls, (initarg, configvar, type))
@@ -488,7 +488,7 @@ class ExternalTool(Filter):
                 raise FilterError(
                     '%s: subprocess returned a non-success result code: '
                     '%s, stdout=%s, stderr=%s' % (
-                        cls.name or cls.__name__, 
+                        cls.name or cls.__name__,
                         proc.returncode, stdout, stderr))
             else:
                 if output_file.created:
@@ -577,13 +577,13 @@ CODE_FILES = ['.py', '.pyc', '.so']
 
 def is_module(name):
     """Is this a recognized module type?
-    
+
     Does this name end in one of the recognized CODE_FILES extensions?
-    
-    The file is assumed to exist, as unique_modules has found it using 
+
+    The file is assumed to exist, as unique_modules has found it using
     an os.listdir() call.
-    
-    returns the name with the extension stripped (the module name) or 
+
+    returns the name with the extension stripped (the module name) or
         None if the name does not appear to be a module
     """
     for ext in CODE_FILES:
@@ -593,31 +593,31 @@ def is_module(name):
 
 def is_package(directory):
     """Is the (fully qualified) directory a python package?
-    
+
     """
     for ext in ['.py', '.pyc']:
         if os.path.exists(os.path.join(directory, '__init__'+ext)):
-            return True 
+            return True
 
 
 def unique_modules(directory):
-    """Find all unique module names within a directory 
-    
-    For each entry in the directory, check if it is a source 
-    code file-type (using is_code(entry)), or a directory with 
+    """Find all unique module names within a directory
+
+    For each entry in the directory, check if it is a source
+    code file-type (using is_code(entry)), or a directory with
     a source-code file-type at entry/__init__.py[c]?
-    
-    Filter the results to only produce a single entry for each 
+
+    Filter the results to only produce a single entry for each
     module name.
-    
+
     Filter the results to not include '_' prefixed names.
-    
+
     yields each entry as it is encountered
     """
     found = {}
     for entry in sorted(os.listdir(directory)):
         if entry.startswith('_'):
-            continue 
+            continue
         module = is_module(entry)
         if module:
             if module not in found:
@@ -625,8 +625,8 @@ def unique_modules(directory):
                 yield module
         elif is_package(os.path.join(directory, entry)):
             if entry not in found:
-                found[entry] = entry 
-                yield entry 
+                found[entry] = entry
+                yield entry
 
 
 def load_builtin_filters():

--- a/src/webassets/filter/less.py
+++ b/src/webassets/filter/less.py
@@ -87,7 +87,7 @@ class Less(ExternalTool):
 
     def input(self, in_, out, source_path, **kw):
         # Set working directory to the source file so that includes are found
-        args = [self.less or 'lessc']
+        args = self.parse_binary(self.less or 'lessc')
         if self.line_numbers:
             args.append('--line-numbers=%s' % self.line_numbers)
         if self.extra_args:


### PR DESCRIPTION
In attempting to invoke webassets on my Windows system, I ran into the following dilemma: node/npm installs the less binary as 'node_modules/bin/lessc' (with no extension). Windows doesn't support invoking scripts based on hashbang. Therefore, to invoke less, I must invoke node directly (i.e. `node node_modules/bin/lessc`). However, webassets doesn't allow for this form of invocation. Thus, when I try to run webassets, it's never able to find the lessc binary (regardless what values I pass for LESS_BIN).

This patch changes that. It creates a new classmethod in ExternalTool to resolve a string to a series of arguments suitable for passing to subprocess functions. I've included some doctests for clarity, but the method essentially just invokes shlex.split. After installing this patch, I'm able to pass a more complex binary such as:

```
environment.config['less_bin'] = 'node node_modules/less/bin/lessc'
```

I believe this approach is sound and backward-compatible. Please consider pulling it in and expanding its usage to the other ExternalTools.