### PR TITLE
Add global flag to Stylus installation note

### DIFF
--- a/src/webassets/filter/stylus.py
+++ b/src/webassets/filter/stylus.py
@@ -11,7 +11,7 @@ class Stylus(ExternalTool):
     Requires the Stylus executable to be available externally. You can install
     it using the `Node Package Manager <http://npmjs.org/>`_::
 
-        $ npm install stylus
+        $ npm install -g stylus
 
     Supported configuration options:
 


### PR DESCRIPTION
Without the `-g` flag Stylus would be installed locally into `./node_modules`
