### PR TITLE
Allow skipping bundles based on the debug level

### DIFF
--- a/docs/bundles.rst
+++ b/docs/bundles.rst
@@ -43,6 +43,12 @@ arguments:
   .. warning::
     Currently, using ``depends`` disables caching for a bundle.
 
+* ``require_production`` - When set to ``True`` or ``False`` the bundle will be
+  skipped if the Environment's debug level does not match the inverse of this
+  settings: When set to ``True``, the debug level must be ``False``, when set to
+  ``False`` the debug level must not be ``False`` (both ``"merge"`` and ``True``
+  are fine).
+
 
 Nested bundles
 --------------

--- a/src/webassets/bundle.py
+++ b/src/webassets/bundle.py
@@ -54,6 +54,7 @@ class Bundle(object):
         self.depends = options.pop('depends', [])
         self.version = options.pop('version', [])
         self.extra = options.pop('extra', {})
+        self.require_production = options.pop('require_production', None)
         if options:
             raise TypeError("got unexpected keyword argument '%s'" %
                             options.keys()[0])
@@ -239,6 +240,13 @@ class Bundle(object):
             output = output % {'version': version or self.get_version(env)}
         return output
 
+    def _should_build(self, env):
+        """Check if the bundle should be built in the current debug level.
+        """
+        if self.require_production is None:
+            return True
+        return self.require_production == (not env.debug)
+
     def __hash__(self):
         """This is used to determine when a bundle definition has changed so
         that a rebuild is required.
@@ -378,6 +386,8 @@ class Bundle(object):
         hunks = []
         for item, cnt in resolved_contents:
             if isinstance(cnt, Bundle):
+                if not cnt._should_build(env):
+                    continue
                 # Recursively process nested bundles.
                 hunk = cnt._merge_and_apply(
                     env, output, force, current_debug_level,
@@ -558,6 +568,8 @@ class Bundle(object):
         env = self._get_env(env)
         hunks = []
         for bundle, extra_filters in self.iterbuild(env):
+            if not bundle._should_build(env):
+                continue
             hunks.append(bundle._build(
                 env, extra_filters, force=force, output=output,
                 disable_cache=disable_cache))

--- a/src/webassets/bundle.py
+++ b/src/webassets/bundle.py
@@ -601,6 +601,15 @@ class Bundle(object):
         else:
             yield self, []
 
+    def iterbundles(self):
+        """Iterate over the bundles and all sub-bundles.
+        """
+        yield self
+        for item in self.contents:
+            if isinstance(item, Bundle):
+                for sub in item.iterbundles():
+                    yield sub
+
     def _make_output_url(self, env):
         """Return the output url, modified for expire header handling.
         """

--- a/tests/test_bundle_build.py
+++ b/tests/test_bundle_build.py
@@ -243,6 +243,65 @@ class TestBuildWithVariousDebugOptions(TempEnvironmentHelper):
         assert self.get('out') == 'Afoo\nBfoo'
 
 
+class TestBuildWithDebugRequired(TempEnvironmentHelper):
+    """Test build behavior with respect to the required debug level of bundles.
+    """
+
+    def test_no_debug_mode_required(self):
+        """When no debug level is required the bundle should be built no
+        matter which debug level is set"""
+        # No debug level set
+        self.mkbundle('in1', 'in2', output='out').build()
+        assert self.get('out') == 'A\nB'
+        os.unlink(self.path('out'))
+        # Debug level 'merge'
+        self.env.debug = 'merge'
+        self.mkbundle('in1', 'in2', output='out').build()
+        assert self.get('out') == 'A\nB'
+        os.unlink(self.path('out'))
+        # Debug level True
+        self.env.debug = True
+        self.mkbundle('in1', 'in2', output='out').build()
+        assert self.get('out') == 'A\nB'
+
+    def test_requiring_debug_mode(self):
+        """When a debug level is required the bundle should only be built if
+        the levels match."""
+        self.env.debug = 'merge'
+        # Wrong level
+        self.mkbundle('in1', 'in2', output='out',
+                      require_production=True).build()
+        assert not self.exists('out')
+        # Matching level. Merge/True are handled in the same way.
+        self.mkbundle('in1', 'in2', output='out',
+                      require_production=False).build()
+        assert self.get('out') == 'A\nB'
+        os.unlink(self.path('out'))
+        self.env.debug = True
+        self.mkbundle('in1', 'in2', output='out',
+                      require_production=False).build()
+        assert self.get('out') == 'A\nB'
+
+    def test_nested_bundle_with_requirement(self):
+        """When a requirement is specified for a nested bundle it may not affect
+        any files/bundles in the outer bundle."""
+        inner = self.mkbundle('in2', require_production=False)
+        b = self.mkbundle('in1', inner, 'in3', output='out')
+        b.build()
+        assert self.get('out') == 'A\nC'
+        os.unlink(self.path('out'))
+        # Let the env's debug level be ok
+        b.env.debug = True
+        b.build()
+        assert self.get('out') == 'A\nB\nC'
+        os.unlink(self.path('out'))
+        # Remove the requirement
+        b.env.debug = False
+        inner.require_production = None
+        b.build()
+        assert self.get('out') == 'A\nB\nC'
+
+
 class ReplaceFilter(Filter):
     """Filter that does a simple string replacement.
     """


### PR DESCRIPTION
Currently there is no nice way to skip a whole bundle e.g. in production mode or in debug mode. Using a custom filter for it is tricky since to handle rebuilds properly `id()` needs to know the current debug state which is not available in that method.

Because of this I implemented a new `Bundle` argument `require_production` that will skip the bundle if necessary. It defaults to `None` and setting it to a boolean value will require either `debug == False` or one of the two non-production debug modes (`debug == True` or `debug == 'merge'`).

While my unit tests pass and everything seems to work fine I'm not completely sure if my `DebugRequirementUpdater` is implemented properly (mostly the usage of `self.__bundle_build_states` to store the information if a bundle has been built the last time). I'm looking forward for feedback on it!