### PR TITLE
Allow filters to provide paths for "depends"

### DIFF
--- a/src/webassets/bundle.py
+++ b/src/webassets/bundle.py
@@ -275,15 +275,15 @@ class Bundle(object):
                     filter_hash = (filter_,"deps")
                     if filter_deps is None:
                         # if not yet resolved, load from cache
-                        filter_deps = env.cache.get(filter_hash) if env.cache else []
-                    elif env.cache:
-                        env.cache.set(filter_hash, filter_deps)
+                        filter_deps = ctx.cache.get(filter_hash) if ctx.cache else []
+                    elif ctx.cache:
+                        ctx.cache.set(filter_hash, filter_deps)
                     if filter_deps:
                         resolved.extend(filter_deps)
             if self.depends:
                 for item in self.depends:
                     try:
-                        result = ctx.resolver.resolve_source(item)
+                        result = ctx.resolver.resolve_source(ctx, item)
                     except IOError as e:
                         raise BundleError(e)
                     if not isinstance(result, list):
@@ -566,7 +566,7 @@ class Bundle(object):
         
         # Resolve deps second time and after building - in case filter
         # didn't know them before.
-        self.resolve_depends(env, True)
+        self.resolve_depends(ctx, True)
         
         return ret
 

--- a/src/webassets/filter/pyscss.py
+++ b/src/webassets/filter/pyscss.py
@@ -2,6 +2,7 @@ import os
 
 from webassets.filter import Filter
 from webassets.utils import working_directory
+import os
 
 
 __all__ = ('PyScss',)
@@ -73,6 +74,10 @@ class PyScss(Filter):
         'assets_url': 'PYSCSS_ASSETS_URL',
     }
     max_debug_level = None
+    depends = None
+    
+    def find_dependencies(self):
+        return self.depends
 
     def setup(self):
         super(PyScss, self).setup()
@@ -136,3 +141,5 @@ class PyScss(Filter):
             # to stdout, via logging. We might have to do something about
             # this, and evaluate such problems to an exception.
             out.write(scss.compile())
+            
+            self.depends = list(os.path.join(f.parent_dir, f.filename) for f in scss.source_files)


### PR DESCRIPTION
aka automatic dependency detection.. by filters.
Not sure if it is the best way to bite it but looks easy and problem free (?).

Problem is discussed in #186
In this implementation if filter at any given time knows about existence of other deps (eg. after compass sources compilation or before when manually parsing files) it should just set depends property.
