### PR TITLE
Setting pyscss's load paths in scss.config, where it looks for them.

### DIFF
--- a/src/webassets/filter/pyscss.py
+++ b/src/webassets/filter/pyscss.py
@@ -88,7 +88,7 @@ class PyScss(Filter):
 
         # Only the dev version appears to support a list
         if self.load_paths:
-            scss.LOAD_PATHS = ','.join(self.load_paths)
+            scss.config.LOAD_PATHS = ','.join(self.load_paths)
 
         # These are needed for various helpers (working with images
         # etc.). Similar to the compass filter, we require the user


### PR DESCRIPTION
While working on a Pelican site with the assets plugin, I noticed that my PYSCSS_LOAD_PATHS was being ignored.  Digging in the source code for pyScss, I noticed that it looks in scss.config.LOAD_PATHS, but webassets was just putting them in scss.LOAD_PATHS.  This changed happened in pyScss 1.1.5 and you updated the other settings, but it looks like you forgot LOAD_PATHS in https://github.com/miracle2k/webassets/commit/aa414f5c6d77bbd4f196d8d02afca60989bf013c . This patch fixes that.
