### PR TITLE
Indent and sort keys in the JSON manifest

### DIFF
--- a/src/webassets/version.py
+++ b/src/webassets/version.py
@@ -276,7 +276,7 @@ class JsonManifest(FileManifest):
 
     def _save_manifest(self):
         with open(self.filename, 'w') as f:
-            self.json.dump(self.manifest, f)
+            self.json.dump(self.manifest, f, indent=4, sort_keys=True)
 
 
 class CacheManifest(Manifest):


### PR DESCRIPTION
This makes it easier to incorporate under version control since the file is less likely to change, and if so, can be diffed/merged more easily.
