### PR TITLE
Fixed encoding error on writing merged assets to file.

### DIFF
--- a/src/webassets/merge.py
+++ b/src/webassets/merge.py
@@ -161,7 +161,7 @@ class MemoryHunk(BaseHunk):
     def save(self, filename):
         f = open(filename, 'w', encoding='utf-8')
         try:
-            f.write(self.data())
+            f.write(self.data().encode('utf8'))
         finally:
             f.close()
 


### PR DESCRIPTION
Not sure if this just a Windows issue?

Also, non-ascii characters in our css/js -- where?
