### PR TITLE
remove unicode indicator in python2 unicode string

### DIFF
--- a/src/webassets/filter/compass.py
+++ b/src/webassets/filter/compass.py
@@ -57,6 +57,9 @@ class CompassConfig(dict):
                 return '{%s}' % ', '.join("'%s' => '%s'" % i for i in val.items())
             elif isinstance(val, tuple):
                 val = list(val)
+            elif isinstance(val, six.text_type) and not six.PY3:
+                # remove unicode indicator in python2 unicode string
+                return repr(val.encode('utf-8'))
             # works fine with strings and lists
             return repr(val)
         return '\n'.join(['%s = %s' % (k, string_rep(v)) for k, v in self.items()])


### PR DESCRIPTION
When an item of `CompassConfig` is given as a `unicode` type in Python2,
the `to_string` method breaks ruby syntax, e.g.:

```
project_path = u'/path/to/project'
```

This pull request solve this problem with encoding Python2 unicode string into `'utf-8'` string.
