### PR TITLE
Cleancss as an input filter to fix import inlining

### DIFF
--- a/src/webassets/filter/cleancss.py
+++ b/src/webassets/filter/cleancss.py
@@ -20,3 +20,8 @@ class CleanCSS(ExternalTool):
 
     def output(self, _in, out, **kw):
         self.subprocess([self.binary or 'cleancss'], out, _in)
+
+    def input(self, _in, out, **kw):
+        args = [self.binary or 'cleancss', '--root', os.path.dirname(kw['source_path'])]
+        self.subprocess(args, out, _in)
+


### PR DESCRIPTION
cleancss is the only webassets filter that supports CSS import inlining(AFAIK). But to do that it needs to know the directory path of the CSS file it's working on, which is only accessible to input filters.

We provide an input function that passes the --root argument to cleancss to fix this issue.

We keep the output filter as an added bonus to remove new lines between files processed this way.
