### PR TITLE
fix command line filter on windows #156

### DIFF
--- a/src/webassets/filter/__init__.py
+++ b/src/webassets/filter/__init__.py
@@ -490,7 +490,8 @@ class ExternalTool(six.with_metaclass(ExternalToolMetaclass, Filter)):
                 # StringIO objects (which are not supported by subprocess)
                 stdout=subprocess.PIPE,
                 stdin=subprocess.PIPE,
-                stderr=subprocess.PIPE)
+                stderr=subprocess.PIPE,
+                shell=os.name == 'nt')
             data = (data.read() if hasattr(data, 'read') else data)
             if data is not None:
                 data = data.encode('utf-8')


### PR DESCRIPTION
This is patch for #156.
Without this patch, command line filter(something like less, sass, coffeescript,,,) is not working on windows.
#156 is very old issue and solution is exist, but not merged into source.

so, I send pull request to remind.
