### PR TITLE
fixed UTF-8 error on Mac OSX

### DIFF
--- a/src/webassets/filter/compass.py
+++ b/src/webassets/filter/compass.py
@@ -171,8 +171,8 @@ class Compass(Filter):
             # image and the css output file, the latter being in a temporary
             # directory in our case.
             config = CompassConfig(
-                project_path=self.env.directory,
-                http_path=self.env.url,
+                project_path=str(self.env.directory),
+                http_path=str(self.env.url),
                 http_images_dir='',
                 http_stylesheets_dir='',
                 http_fonts_dir='',


### PR DESCRIPTION
After updating Ruby and Compass (might be even some more dependencies that I am not aware of) I faced an error regarding to a 'missing_method'. It seems like that when using en_US.UTF-8 as part of the locale python is passing string with 'u' and ruby cannot find the correct method, e.g u'project_path' instead of 'project_path' 

The errors message was:
compass: subprocess had error: stderr=NoMethodError on line ["264"] of
/Users/USERNAME/.rvm/gems/ruby-2.0.0-p247@global/gems/compass-0.12.2/lib/compass/configuration/inheritance.rb:
u

Using:
OSX 10.8.5
Python 2.7 
Ruby 2.0.0p247
Compass 0.12.2
Gem: 2.0.6

Using string cast seems to fix the issue.
I am not sure that that's the best way to do that, but it worked for me at the moment. 
