### PR TITLE
Support files lists or tuples in Jinja2 assets block.

### DIFF
--- a/src/webassets/ext/jinja2.py
+++ b/src/webassets/ext/jinja2.py
@@ -75,7 +75,11 @@ class AssetsExtension(Extension):
             # Otherwise assume a source file is given, which may be any
             # expression, except note that strings are handled separately above.
             else:
-                files.append(parser.parse_expression())
+                expression = parser.parse_expression()
+                if isinstance(expression, (nodes.List, nodes.Tuple)):
+                    files.extend(expression.iter_child_nodes())
+                else:
+                    files.append(expression)
 
         # Parse the contents of this tag
         body = parser.parse_statements(['name:endassets'], drop_needle=True)

--- a/tests/test_ext/test_jinja2.py
+++ b/tests/test_ext/test_jinja2.py
@@ -63,6 +63,18 @@ class TestTemplateTag(object):
         self.render_template('"file1", "file2", "file3"')
         assert self.the_bundle.contents == ('file1', 'file2', 'file3',)
 
+    def test_reference_files_list(self):
+        self.render_template('["file1", "file2", "file3"]')
+        assert self.the_bundle.contents == ('file1', 'file2', 'file3',)
+
+    def test_reference_files_tuple(self):
+        self.render_template('("file1", "file2", "file3")')
+        assert self.the_bundle.contents == ('file1', 'file2', 'file3',)
+
+    def test_reference_files_mixed(self):
+        self.render_template('"file1", ("file2", "file3")')
+        assert self.the_bundle.contents == ('file1', 'file2', 'file3',)
+
     def test_reference_mixed(self):
         self.render_template('"foo_bundle", "file2", "file3"')
         assert self.the_bundle.contents == (self.foo_bundle, 'file2', 'file3',)


### PR DESCRIPTION
`{% assets 'f1', ('f2', 'f3'), ['f4'] %}` renders like `{% assets 'f1', 'f2', 'f3', 'f4' %}`.

It helps composition, enabling something like `*varargs` (not supported by Jinja2).

Close #277.
