### PR TITLE
JST filter does not correctly escape backslashes in string literals

### DIFF
--- a/src/webassets/filter/jst.py
+++ b/src/webassets/filter/jst.py
@@ -1,4 +1,8 @@
 import os
+try:
+    import json
+except ImportError:
+    import simplejson as json
 from webassets.filter import Filter
 from webassets.utils import common_path_prefix
 
@@ -148,14 +152,14 @@ class JST(JSTemplateFilter):
             out.write("%s\n" % _jst_script)
 
         for name, hunk in self.iter_templates_with_base(hunks):
-            # Make it a valid Javascript string. Is this smart enough?
-            contents = hunk.data().replace('\n', '\\n').replace("'", r"\'")
+            # Make it a valid Javascript string.
+            contents = json.dumps(hunk.data())
 
             out.write("%s['%s'] = " % (namespace, name))
             if self.template_function is False:
-                out.write("'%s';\n" % (contents))
+                out.write("%s;\n" % (contents))
             else:
-                out.write("%s('%s');\n" % (
+                out.write("%s(%s);\n" % (
                     self.template_function or 'template', contents))
 
         if self.bare is False:

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1047,7 +1047,7 @@ class TestJST(TempEnvironmentHelper):
         """Output strings directly if template_function == False."""
         self.env.config['JST_COMPILER'] = False
         self.mkbundle('templates/*.jst', filters='jst', output='out.js').build()
-        assert "JST['foo'] = '" in self.get('out.js')
+        assert "JST['foo'] = \"" in self.get('out.js')
 
     def test_namespace_config(self):
         self.env.config['JST_NAMESPACE'] = 'window.Templates'
@@ -1112,6 +1112,13 @@ class TestJST(TempEnvironmentHelper):
         bundle.build(force=True)
 
         assert 'new value' in self.get('out.js')
+
+    def test_backslashes_escaped(self):
+        """Test that JavaScript string literals are correctly escaped.
+        """
+        self.create_files({'backslashes.jst': """<input type="text" pattern="\S*"/>"""})
+        self.mkbundle('*.jst', filters='jst', output='out.js').build()
+        assert r"""template("<input type=\"text\" pattern=\"\\S*\"/>")""" in self.get('out.js')
 
 
 class TestHandlebars(TempEnvironmentHelper):


### PR DESCRIPTION
If a template contains a backslash (for example, as part of a regexp on `<input pattern=""/>` or anywhere else) the backslash is not escaped when the template is converted to a JavaScript string literal by the JST filter.

This patch uses json.dumps to produce JavaScript string literals rather than trying to do all the escaping correctly by hand.
