### PR TITLE
Repaired missing os imports in various filters

### DIFF
--- a/src/webassets/filter/cleancss.py
+++ b/src/webassets/filter/cleancss.py
@@ -1,3 +1,5 @@
+import os
+
 from webassets.filter import ExternalTool
 
 

--- a/src/webassets/filter/closure_templates.py
+++ b/src/webassets/filter/closure_templates.py
@@ -27,7 +27,7 @@ CLOSURE_EXTRA_ARGS
 """
 
 import subprocess
-from os import path
+import os
 import tempfile
 
 from webassets.exceptions import FilterError


### PR DESCRIPTION
Hello there,

It seems that the **os** import was missing from the **Clean CSS** and **Closure Template** filters.  I noticed this when using cleancss and receiving the following exception:

```
Traceback (most recent call last):
  File "/home/fots/.virtualenv/flask/lib/python2.7/site-packages/flask/app.py", line 1836, in __call__
    return self.wsgi_app(environ, start_response)
  File "/home/fots/.virtualenv/flask/lib/python2.7/site-packages/flask/app.py", line 1820, in wsgi_app
    response = self.make_response(self.handle_exception(e))
  File "/home/fots/.virtualenv/flask/lib/python2.7/site-packages/flask/app.py", line 1403, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/home/fots/.virtualenv/flask/lib/python2.7/site-packages/flask/app.py", line 1817, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/fots/.virtualenv/flask/lib/python2.7/site-packages/flask/app.py", line 1477, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/fots/.virtualenv/flask/lib/python2.7/site-packages/flask/app.py", line 1381, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/home/fots/.virtualenv/flask/lib/python2.7/site-packages/flask/app.py", line 1475, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/fots/.virtualenv/flask/lib/python2.7/site-packages/flask/app.py", line 1461, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/fots/flaskage/application/views/flaskage.py", line 8, in index
    return render_template('index.html')
  File "/home/fots/.virtualenv/flask/lib/python2.7/site-packages/flask/templating.py", line 128, in render_template
    context, ctx.app)
  File "/home/fots/.virtualenv/flask/lib/python2.7/site-packages/flask/templating.py", line 110, in _render
    rv = template.render(context)
  File "/home/fots/.virtualenv/flask/lib/python2.7/site-packages/jinja2/environment.py", line 969, in render
    return self.environment.handle_exception(exc_info, True)
  File "/home/fots/.virtualenv/flask/lib/python2.7/site-packages/jinja2/environment.py", line 742, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/home/fots/flaskage/application/templates/index.html", line 1, in top-level template code
    {% extends "layout.html" %}
  File "/home/fots/flaskage/application/templates/layout.html", line 10, in top-level template code
    {% assets filters="less,cleancss", output="css/bootstrap-custom.css",
  File "/home/fots/.virtualenv/flask/lib/python2.7/site-packages/webassets/ext/jinja2.py", line 185, in _render_assets
    urls = bundle.urls(env=env)
  File "/home/fots/.virtualenv/flask/lib/python2.7/site-packages/webassets/bundle.py", line 685, in urls
    urls.extend(bundle._urls(env, extra_filters, *args, **kwargs))
  File "/home/fots/.virtualenv/flask/lib/python2.7/site-packages/webassets/bundle.py", line 647, in _urls
    *args, **kwargs)
  File "/home/fots/.virtualenv/flask/lib/python2.7/site-packages/webassets/bundle.py", line 504, in _build
    force, disable_cache=disable_cache, extra_filters=extra_filters)
  File "/home/fots/.virtualenv/flask/lib/python2.7/site-packages/webassets/bundle.py", line 429, in _merge_and_apply
    kwargs=item_data)
  File "/home/fots/.virtualenv/flask/lib/python2.7/site-packages/webassets/merge.py", line 272, in apply
    return self._wrap_cache(key, func)
  File "/home/fots/.virtualenv/flask/lib/python2.7/site-packages/webassets/merge.py", line 219, in _wrap_cache
    content = func().getvalue()
  File "/home/fots/.virtualenv/flask/lib/python2.7/site-packages/webassets/merge.py", line 252, in func
    getattr(filter, type)(data, out, **kwargs_final)
  File "/home/fots/.virtualenv/flask/lib/python2.7/site-packages/webassets/filter/cleancss.py", line 25, in input
    args = [self.binary or 'cleancss', '--root', os.path.dirname(kw['source_path'])]
NameError: global name 'os' is not defined
```

I highly suggest that you install **flake8** and validate all your code as I found a few other problems when running the validation myself.

To install flake8, simply use:

``` bash
pip install flake8
```

You may then validate all your code as follows:

``` bash
cd webassets/
flake8
```

Or check certain files using:

``` bash
flake8 somefile.py
```

Cheers
Fotis
