### PR TITLE
bugfix with requirejs filter

### DIFF
--- a/src/webassets/filter/requirejs.py
+++ b/src/webassets/filter/requirejs.py
@@ -122,7 +122,7 @@ class RequireJSFilter(ExternalTool):
             self.argv = ['r.js']
 
         if self.config:
-            self.config = path.join(
+            rel_config = path.join(
                 path.relpath(
                     self.ctx.directory,
                     getcwd()
@@ -139,7 +139,7 @@ class RequireJSFilter(ExternalTool):
             filter(
                 None,
                 ['-o',
-                 self.config if self.config else None,
+                 rel_config if self.config else None,
                  'name={modname}',
                  'out={{output}}',
                  'baseUrl=' + self.baseUrl if self.baseUrl else None,


### PR DESCRIPTION
This fixes the bug discussed [here](https://github.com/miracle2k/webassets/pull/290). I also changed `self.run_in_debug is False` to `not self.run_in_debug` since the first will evaluate to `False` when `self.run_in_debug` is `None`.
