### PR TITLE
added passing load_path settings to Environment on yaml

### DIFF
--- a/src/webassets/loaders.py
+++ b/src/webassets/loaders.py
@@ -193,7 +193,7 @@ class YAMLLoader(object):
 
             # Load environment settings
             for setting in ('debug', 'cache', 'versions', 'url_expire',
-                            'auto_build', 'url', 'directory', 'manifest',
+                            'auto_build', 'url', 'directory', 'manifest', 'load_path',
                             # TODO: The deprecated values; remove at some point
                             'expire', 'updater'):
                 if setting in obj:


### PR DESCRIPTION
YamlLoader doesn't pass `load_path` value to Environment.
Is that considered issue?
