### PR TITLE
compass: update compass filter to utilize the newer 'sourcemap' option

### DIFF
--- a/src/webassets/filter/compass.py
+++ b/src/webassets/filter/compass.py
@@ -240,6 +240,8 @@ class Compass(Filter):
                     path.dirname(kw['output_path']),
                     path.basename(sourcemap_file.name)
                 )
+                if not path.exists(path.dirname(sourcemap_output_filepath)):
+                    os.mkdir(path.dirname(sourcemap_output_filepath))
                 sourcemap_output_file = open(sourcemap_output_filepath, 'w')
                 sourcemap_output_file.write(sourcemap_file.read())
             try:


### PR DESCRIPTION
This updates the Compass filter to work with the `sourcemap` option. It creates a file `_.css.map` in the output directory (where `_.scss` or `_.sass` is the original filename). This file does not have the ability to have a versioned filename, so it is only recommended for local development.
