### PR TITLE
FilesystemCache is not safe for multiple processes

### DIFF
--- a/src/webassets/cache.py
+++ b/src/webassets/cache.py
@@ -17,6 +17,7 @@ import os
 from os import path
 import errno
 import tempfile
+import warnings
 from webassets import six
 from webassets.merge import BaseHunk
 from webassets.filter import Filter, freezedicts
@@ -190,7 +191,10 @@ class FilesystemCache(BaseCache):
         finally:
             f.close()
 
-        return safe_unpickle(result)
+        unpickled = safe_unpickle(result)
+        if unpickled is None:
+            warnings.warn('Ignoring corrupted cache file %s' % filename)
+        return unpickled
 
     def set(self, key, data):
         md5 = '%s' % make_md5(self.V, key)


### PR DESCRIPTION
When multiple processes are sharing a filesystem cache directory, the cache files can be corrupted (contents written into the same file multiple times). A process may also see incomplete or empty cache files if it reads from cache while another process is in the middle of writing to it.

Currently the filesystem cache papers over these issues by using `safe_pickle`: it essentially pretends that a cache entry doesn't exist if the cache file was empty or corrupted.

You can see the problem in action by hacking up the source a bit:
1. Add a `print` or `warnings.warn` when a cache file cannot be unpickled
2. In the `FilesystemCache.set` method, add a call to `time.sleep` in between `open()` and `.write()`. This simulates a really slow filesystem so that you can hit the race.
3. Configure your web app to use autobuild or build assets during startup
4. Run your application in a container with multiple worker processes, such as gunicorn, or mod_wsgi with processes > 1
5. Send two HTTP requests in quick succession

```
PRETENDING TO WRITE VERY SLOWLY TO assets-cache/.webassets-cache/222379389394b0c9e1b8bcad1503612e
PRETENDING TO WRITE VERY SLOWLY TO assets-cache/.webassets-cache/222379389394b0c9e1b8bcad1503612e
PRETENDING TO WRITE VERY SLOWLY TO assets-cache/.webassets-cache/ac8e8d29d045830c4bbb7f2521bb5862
PRETENDING TO WRITE VERY SLOWLY TO assets-cache/.webassets-cache/ac8e8d29d045830c4bbb7f2521bb5862
PRETENDING TO WRITE VERY SLOWLY TO assets-cache/.webassets-cache/f573b77d26195aaf40a7f663e8755461
PRETENDING TO WRITE VERY SLOWLY TO assets-cache/.webassets-cache/f573b77d26195aaf40a7f663e8755461
PRETENDING TO WRITE VERY SLOWLY TO assets-cache/.webassets-cache/9975a51d4cccc75e089f002a7fa664b5
/usr/lib/python2.6/site-packages/webassets/cache.py:185: UserWarning: Ignoring corrupted cache file assets-cache/.webassets-cache/9975a51d4cccc75e089f002a7fa664b5
  warnings.warn('Ignoring corrupted cache file %s' % filename)
PRETENDING TO WRITE VERY SLOWLY TO assets-cache/.webassets-cache/9975a51d4cccc75e089f002a7fa664b5
```

The filesystem cache should use the standard write-then-rename dance to ensure that cache entries only become visible once they are fully written.
