### PR TITLE
Make the JST filter differentiate between JST_COMPILER = False or None.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,6 +35,7 @@ John Anderson <sontek@gmail.com>
 John Paulett <john@paulett.org>
 johnwlockwood <johnwlockwood@gmail.com>
 Jon Morton <jonanin@gmail.com>
+Josh Jaques <jjaques@gmail.com>
 K0den <your_email@youremail.com>
 Kai Groner <kai@gronr.com>
 Krzysztof Tarnowski <krzysztof.tarnowski@ymail.com>

--- a/src/webassets/filter/jst.py
+++ b/src/webassets/filter/jst.py
@@ -138,7 +138,7 @@ class JST(JSTemplateFilter):
     def setup(self):
         super(JST, self).setup()
         self.include_jst_script = (self.template_function == 'template') \
-                                  or not self.template_function
+                                  or self.template_function is None
 
     def process_templates(self, out, hunks, **kwargs):
         namespace = self.namespace or 'window.JST'

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1064,12 +1064,21 @@ class TestJST(TempEnvironmentHelper):
         self.env.config['JST_COMPILER'] = '_.template'
         self.mkbundle('templates/*', filters='jst', output='out.js').build()
         assert '_.template' in self.get('out.js')
+        # make sure the default builder is not included
+        assert "var template =" not in self.get('out.js')
 
     def test_compiler_is_false(self):
         """Output strings directly if template_function == False."""
         self.env.config['JST_COMPILER'] = False
         self.mkbundle('templates/*.jst', filters='jst', output='out.js').build()
         assert "JST['foo'] = \"" in self.get('out.js')
+        assert "var template =" not in self.get('out.js')
+
+    def test_compiler_is_none(self):
+        """Make sure the default builder is included
+        if compiler is not specified """
+        self.mkbundle('templates/*.jst', filters='jst', output='out.js').build()
+        assert "var template =" in self.get('out.js')
 
     def test_namespace_config(self):
         self.env.config['JST_NAMESPACE'] = 'window.Templates'


### PR DESCRIPTION
This makes it more efficient when JST_COMPILER is set to None,
because excludes the default compiler code in the output file.

See Issue #278
