### PR TITLE
Rename files only after file is closed

### DIFF
--- a/src/webassets/cache.py
+++ b/src/webassets/cache.py
@@ -205,7 +205,7 @@ class FilesystemCache(BaseCache):
             with os.fdopen(fd, 'wb') as f:
                 pickle.dump(data, f)
                 f.flush()
-                os.rename(temp_filename, filename)
+            os.rename(temp_filename, filename)
         except:
             os.unlink(temp_filename)
             raise


### PR DESCRIPTION
Otherwise this will break on windows where write mode also means exclusive access to the file.
