### PR TITLE
Create UTF-8 encoded files in tests

### DIFF
--- a/src/webassets/test.py
+++ b/src/webassets/test.py
@@ -52,6 +52,7 @@ class TempDirHelper(object):
         """Helper that allows to quickly create a bunch of files in
         the media directory of the current test run.
         """
+        import codecs
         # Allow passing a list of filenames to create empty files
         if not hasattr(files, 'items'):
             files = dict(map(lambda n: (n, ''), files))
@@ -59,7 +60,7 @@ class TempDirHelper(object):
             dirs = path.dirname(self.path(name))
             if not path.exists(dirs):
                 os.makedirs(dirs)
-            f = open(self.path(name), 'w')
+            f = codecs.open(self.path(name), 'w', 'utf-8')
             f.write(data)
             f.close()
 


### PR DESCRIPTION
This is something I had in my fork for a long time.

I've been having problems with UTF-8 encoded assets, especially with `uglifyjs` filter, so I've patched `webassets` and also extended filter tests with some Unicode strings. Meanwhile, only the tests are left, since relevant parts in actual code have been patched by other people.
