### PR TITLE
Repaired remaining subprocess calls for Windows users

### DIFF
--- a/src/webassets/filter/closure_templates.py
+++ b/src/webassets/filter/closure_templates.py
@@ -91,7 +91,8 @@ class ClosureTemplateFilter(JSTemplateFilter):
             # StringIO objects (which are not supported by subprocess)
             stdout=subprocess.PIPE,
             stdin=subprocess.PIPE,
-            stderr=subprocess.PIPE)
+            stderr=subprocess.PIPE,
+            shell=(os.name == 'nt'))
         stdout, stderr = proc.communicate()
         if proc.returncode:
             raise FilterError('%s: subprocess returned a '

--- a/src/webassets/filter/coffeescript.py
+++ b/src/webassets/filter/coffeescript.py
@@ -45,7 +45,8 @@ class CoffeeScript(Filter):
             proc = subprocess.Popen([binary, args],
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE)
+                stderr=subprocess.PIPE,
+                shell=(os.name == 'nt'))
         except OSError as e:
             if e.errno == 2:
                 raise Exception("coffeescript not installed or in system path for webassets")

--- a/src/webassets/filter/handlebars.py
+++ b/src/webassets/filter/handlebars.py
@@ -1,4 +1,5 @@
 import subprocess
+import os
 from os import path
 
 from webassets.exceptions import FilterError
@@ -63,7 +64,8 @@ class Handlebars(JSTemplateFilter):
         proc = subprocess.Popen(
             args, stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE)
+            stderr=subprocess.PIPE,
+            shell=(os.name == 'nt'))
         stdout, stderr = proc.communicate()
 
         if proc.returncode != 0:

--- a/src/webassets/filter/jade.py
+++ b/src/webassets/filter/jade.py
@@ -90,7 +90,8 @@ class Jade(Filter):
         proc = subprocess.Popen(self.argv,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE)
+            stderr=subprocess.PIPE,
+            shell=(os.name == 'nt'))
         stdout, stderr = proc.communicate(_in.read())
 
         if proc.returncode != 0:

--- a/src/webassets/filter/typescript.py
+++ b/src/webassets/filter/typescript.py
@@ -40,7 +40,8 @@ class TypeScript(Filter):
             args,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE)
+            stderr=subprocess.PIPE,
+            shell=(os.name == 'nt'))
         stdout, stderr = proc.communicate()
         if proc.returncode != 0:
             raise FilterError("typescript: subprocess had error: stderr=%s," % stderr +


### PR DESCRIPTION
Hello there Michael, hope you're doing well :smile: 

This pull requests completes the fix in https://github.com/miracle2k/webassets/pull/273/files across all remaining subprocess Popen calls.  I noticed this while trying to use coffeescript on Windows and realising that its subprocess call was missed, so I went through and did all the ones which were missed and repaired them.  I can at least confirm that coffeescript now works correctly on Windows.

Kindest Regards
Fotis
