### PR TITLE
Abitlity to sort assets within a bundle

### DIFF
--- a/src/webassets/bundle.py
+++ b/src/webassets/bundle.py
@@ -253,7 +253,7 @@ class Bundle(object):
 
             # A hook for sorting the bundle contents in a certain order
             if self.sort:
-                resolved = self.sort(resolved)
+                resolved = self.sort(ctx, resolved)
 
             self._resolved_contents = resolved
 

--- a/src/webassets/filter/jsdeps.py
+++ b/src/webassets/filter/jsdeps.py
@@ -55,7 +55,7 @@ class JSDepSort:
         pre_visits.add(path)
 
         for dep in deps:
-            dep_path = self.resolve_dep(dep, content_map)
+            dep_path = self.resolve_dep(dep, content_map, path)
             if not dep_path:
                 raise Exception(
                     'Could not resolve dependency "{}" of source'
@@ -75,13 +75,14 @@ class JSDepSort:
 
         post_visits.add(path)
 
-    def resolve_dep(self, dep, content_map):
+    def resolve_dep(self, dep, content_map, included_by):
         if dep.startswith("/"):
             #We are an absolute path.  Why would you do this???
             if dep in content_map:
                 return dep
             else:
-                raise Exception('Dependency "{}" not in this bundle.'.format(dep))
+                raise Exception('Dependency "{}" not in this bundle. (Included by {})'
+                        .format(dep, included_by))
 
         for search_path in self.search_path:
             path = os.path.join(search_path, dep)
@@ -89,6 +90,7 @@ class JSDepSort:
             if path in content_map:
                 return path 
             
-        raise Exception('Dependency "{}" not found in this bundle.'.format(dep))
+        raise Exception('Dependency "{}" not found in this bundle. (Included by {})'
+                .format(dep, included_by))
         
 

--- a/tests/test_bundle_urls.py
+++ b/tests/test_bundle_urls.py
@@ -84,7 +84,7 @@ class TestUrlsVarious(BaseUrlsTester):
     def test_sorting(self):
         """Specifying a sorting function should sort the resolved list of files
         """
-        def sortFunc(files):
+        def sortFunc(cxt, files):
             return sorted(files, key=(lambda f: f[1]))
 
         self.env.debug = True


### PR DESCRIPTION
Hi, I realize you've been working on require.js support, but I also like how Sprockets in the Rails asset pipeline is able to combine js files while taking dependencies into account by looking for a ("//= require <dep.js>") directive in the js file.  It's a bit simpler if all you need is the ability to break your js into a file hierarchy and specify dependencies between files.

I implemented this for a small project of mine, and I thought I should share in case you're interested in incorporating it into your own branch.  It just adds a new extension point in the bundle code, and the rest is implemented as a sort extension.

Thanks

