### PR TITLE
Ensure that the assets cache is readable.

### DIFF
--- a/src/webassets/cache.py
+++ b/src/webassets/cache.py
@@ -16,6 +16,7 @@ also serve in other places.
 import os
 from os import path
 import errno
+import stat
 import tempfile
 import warnings
 from webassets import six
@@ -207,6 +208,7 @@ class FilesystemCache(BaseCache):
                 f.flush()
             if os.path.isfile(filename):
                 os.unlink(filename)
+            os.chmod(temp_filename, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
             os.rename(temp_filename, filename)
         except:
             os.unlink(temp_filename)


### PR DESCRIPTION
Files created by mkstemp are "readable and writable only by the creating user ID."
The cache needs to be readable by the website user, even if it's created by root,
so change the mode on files added to it after they are created.