### PR TITLE
Avoid encoding errors on compass filter

### DIFF
--- a/src/webassets/filter/compass.py
+++ b/src/webassets/filter/compass.py
@@ -245,7 +245,7 @@ class Compass(Filter):
                 sourcemap_output_file = open(sourcemap_output_filepath, 'w')
                 sourcemap_output_file.write(sourcemap_file.read())
             try:
-                out.write(output_file.read())
+                out.write(output_file.read().decode('utf-8'))
             finally:
                 output_file.close()
         finally:


### PR DESCRIPTION
I was using webassets when I got this error on my Sass files.
Looks like it wasn't dealing well with non ascii characters.

    File "/usr/local/Cellar/python/2.7.5/Frameworks/Python.framework/Versions/2.7/lib/python2.7/StringIO.py", line 271, in getvalue
        self.buf += ''.join(self.buflist)
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 43793: ordinal not in range(128)