### PR TITLE
Add in ``encoding`` param to avoid Unicode ascii exception.

### DIFF
--- a/src/webassets/merge.py
+++ b/src/webassets/merge.py
@@ -56,7 +56,7 @@ class BaseHunk(object):
         raise NotImplementedError()
 
     def save(self, filename):
-        with open(filename, 'w') as f:
+        with open(filename, 'w', encoding='utf-8') as f:
             f.write(self.data())
 
 


### PR DESCRIPTION
Encoding fix.

See Issue #350 