### PR TITLE
Fix MemoryHunk.__repr__

### DIFF
--- a/src/webassets/merge.py
+++ b/src/webassets/merge.py
@@ -147,8 +147,7 @@ class MemoryHunk(BaseHunk):
         # a question of performance, make sure to log in such a way that
         # when logging is disabled, this won't be called, i.e.: don't
         # %s-format yourself, let logging do it as needed.
-        # TODO: Add a test to ensure this isn't called.
-        return '<%s %s>' % (self.__class__.__name__, hash_func(self.data))
+        return '<%s %s>' % (self.__class__.__name__, hash_func(self))
 
     def mtime(self):
         pass

--- a/tests/test_bundle_build.py
+++ b/tests/test_bundle_build.py
@@ -5,17 +5,45 @@ more likely` found in `test_bundle_various.py``.
 """
 
 
+import logging
 import os
+import sys
+from mock import patch
 from nose.tools import assert_raises
 import pytest
 from webassets import Bundle
 from webassets.cache import MemoryCache
 from webassets.exceptions import BuildError, BundleError
 from webassets.filter import Filter
+from webassets.merge import MemoryHunk
 from webassets.test import TempEnvironmentHelper
 from webassets.updater import BaseUpdater, SKIP_CACHE, TimestampUpdater
 
 from tests.helpers import noop
+
+
+class NoisyHandler(logging.StreamHandler):
+    def handleError(self, record):
+        sys.stderr.write('Logged from file %s, line %s\n' % (
+            record.filename, record.lineno))
+        raise
+
+@pytest.fixture
+def debug_logging(request):
+    log = logging.getLogger('webassets.debug')
+    log.setLevel(logging.DEBUG)
+    original_handlers = log.handlers[:]
+    for h in original_handlers:
+        log.removeHandler(h)
+    noisy_handler = NoisyHandler()
+    log.addHandler(noisy_handler)
+    def reset_logging():
+        for h in original_handlers:
+            log.addHandler(h)
+        log.removeHandler(noisy_handler)
+        log.setLevel(logging.ERROR)
+    request.addfinalizer(reset_logging)
+    return log
 
 
 class TestBuildVarious(TempEnvironmentHelper):
@@ -31,6 +59,25 @@ class TestBuildVarious(TempEnvironmentHelper):
 
     def test_nested_bundle(self):
         """A nested bundle."""
+        self.mkbundle('in1', self.mkbundle('in3', 'in4'), 'in2', output='out').build()
+        assert self.get('out') == 'A\nC\nD\nB'
+
+    @patch.object(MemoryHunk, '__repr__', return_value="FOO")
+    def test_repr_not_called(self, repr_mock):
+        """Ensure MemoryHunk.__repr__ isn't called when logging is off."""
+        self.mkbundle('in1', self.mkbundle('in3', 'in4'), 'in2', output='out').build()
+        assert self.get('out') == 'A\nC\nD\nB'
+        assert not repr_mock.called
+
+    @patch.object(MemoryHunk, '__repr__', return_value="FOO")
+    def test_repr_called(self, repr_mock, debug_logging):
+        """Ensure MemoryHunk.__repr__ is called when logging is on."""
+        self.mkbundle('in1', self.mkbundle('in3', 'in4'), 'in2', output='out').build()
+        assert self.get('out') == 'A\nC\nD\nB'
+        assert repr_mock.called
+
+    def test_repr_works(self, debug_logging):
+        """Ensure MemoryHunk.__repr__ logging doesn't raise."""
         self.mkbundle('in1', self.mkbundle('in3', 'in4'), 'in2', output='out').build()
         assert self.get('out') == 'A\nC\nD\nB'
 


### PR DESCRIPTION
`MemoryHunk.__repr__` was using `self.data` instead of `self.data()` (or `self`), causing debug logging to raise. I also added a test to ensure `__repr__` isn't called when logging is off.
