### PR TITLE
don't choke on empty files

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+Unreleased
+    - Prevent filters from crashing if the input file is empty (empty string
+      passed)
+
 0.10.1 (2014-07-03)
     - Python 3 fixes.
     - Windows fix (Ionel Cristian Mărieș).

--- a/src/webassets/filter/__init__.py
+++ b/src/webassets/filter/__init__.py
@@ -496,7 +496,7 @@ class ExternalTool(six.with_metaclass(ExternalToolMetaclass, Filter)):
                 data = data.encode('utf-8')
 
             if input_file.created:
-                if not data:
+                if data is None:
                     raise ValueError(
                         '{input} placeholder given, but no data passed')
                 with open(input_file.filename, 'wb') as f:


### PR DESCRIPTION
If an empty file is passed through a filter, it will choke on it thinking that an empty string is not data. This PR fixes this problem by explicitly checking for `None` rather than making a falsy test:

``` python
Traceback (most recent call last):
  File "/opt/src/smlib.assets/smlib/assets/command.py", line 327, in compile_assets
    env[bundle_name].urls()
  File "/opt/webapp/anweb/local/lib/python2.7/site-packages/webassets/bundle.py", line 787, in urls
    urls.extend(bundle._urls(new_ctx, extra_filters, *args, **kwargs))
  File "/opt/webapp/anweb/local/lib/python2.7/site-packages/webassets/bundle.py", line 746, in _urls
    *args, **kwargs)
  File "/opt/webapp/anweb/local/lib/python2.7/site-packages/webassets/bundle.py", line 600, in _build
    force, disable_cache=disable_cache, extra_filters=extra_filters)
  File "/opt/webapp/anweb/local/lib/python2.7/site-packages/webassets/bundle.py", line 554, in _merge_and_apply
    return filtertool.apply(final, selected_filters, 'output')
  File "/opt/webapp/anweb/local/lib/python2.7/site-packages/webassets/merge.py", line 277, in apply
    return self._wrap_cache(key, func)
  File "/opt/webapp/anweb/local/lib/python2.7/site-packages/webassets/merge.py", line 219, in _wrap_cache
    content = func().getvalue()
  File "/opt/webapp/anweb/local/lib/python2.7/site-packages/webassets/merge.py", line 252, in func
    getattr(filter, type)(data, out, **kwargs_final)
  File "/opt/webapp/anweb/local/lib/python2.7/site-packages/webassets/filter/uglifyjs.py", line 32, in output
    self.subprocess(args, out, _in)
  File "/opt/webapp/anweb/local/lib/python2.7/site-packages/webassets/filter/__init__.py", line 505, in subprocess
    '{input} placeholder given, but no data passed')
ValueError: {input} placeholder given, but no data passed
```
