### PR TITLE
Fix default manifest documentation

### DIFF
--- a/src/webassets/env.py
+++ b/src/webassets/env.py
@@ -520,8 +520,6 @@ class ConfigurationContext(object):
           No manifest is used.
 
       Any custom manifest implementation.
-
-    The default value is ``None``.
     """)
 
     def _set_versions(self, versions):


### PR DESCRIPTION
Hi!

Noticed a small discrepancy in the docs: the default value for `manifest` is `cache` as per line 507. Removing the sentence below it that says the default is `None`.
