### PR TITLE
Add automodule of `webassets.filter` to docs

### DIFF
--- a/docs/custom_filters.rst
+++ b/docs/custom_filters.rst
@@ -289,3 +289,5 @@ More?
 
 You can have a look inside the ``webassets.filter`` module source
 code to see a large number of example filters.
+
+.. automodule:: webassets.filter


### PR DESCRIPTION
* Addresses issue with building documentation inheriting
  `webassets.filter.ExternalTool`.