### PR TITLE
support jsmin.py from v8

### DIFF
--- a/src/webassets/filter/jsmin.py
+++ b/src/webassets/filter/jsmin.py
@@ -35,4 +35,10 @@ class JSMin(Filter):
         self.jsmin = jsmin
 
     def output(self, _in, out, **kw):
-        self.jsmin.JavascriptMinify().minify(_in, out)
+        if hasattr(self.jsmin, 'JavaScriptMinifier'):
+            # jsmin.py from v8
+            minifier = self.jsmin.JavaScriptMinifier()
+            minified = minifier.JSMinify(_in.read())
+            out.write(minified)
+        else:
+            self.jsmin.JavascriptMinify().minify(_in, out)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -549,7 +549,9 @@ class TestBuiltinFilters(TempEnvironmentHelper):
             # Builtin jsmin
             "\nfunction foo(bar){var dummy;document.write(bar);var a=\"Ünícôdè\"}",
             # jsmin from PyPI
-            ' function foo(bar){var dummy;document.write(bar);var a="\xc3\x9cn\xc3\xadc\xc3\xb4d\xc3\xa8";}'
+            ' function foo(bar){var dummy;document.write(bar);var a="\xc3\x9cn\xc3\xadc\xc3\xb4d\xc3\xa8";}',
+            # jsmin from v8
+            '\n\nfunction foo(a){\nvar b;\ndocument.write(a);\nvar c="\xc3\x9cn\xc3\xadc\xc3\xb4d\xc3\xa8";\n}\n\n',
         )
 
     def test_rjsmin(self):


### PR DESCRIPTION
v8 has its [own weird version of jsmin.py](http://v8.googlecode.com/svn/trunk/tools/jsmin.py) (maybe it's the original, or one of the originals, not sure...)

For better or worse, that's the jsmin Python module that is being shipped in Fedora right now so it would be nice if webassets could support it.
