### PR TITLE
Fix for Issue #337, Problem with globs on Windows

### DIFF
--- a/src/webassets/env.py
+++ b/src/webassets/env.py
@@ -1,3 +1,4 @@
+import os
 from os import path
 from itertools import chain
 from webassets import six
@@ -203,6 +204,10 @@ class Resolver(object):
             if needle.startswith(candidate):
                 # Found it!
                 rel_path = needle[len(candidate)+1:]
+                # If there are any subdirs in rel_path, ensure
+                # they use HTML-style path separators, in case
+                # the local OS (Windows!) has a different scheme
+                rel_path = rel_path.replace(os.sep, "/")
                 return url_prefix_join(url, rel_path)
         raise ValueError('Cannot determine url for %s' % filepath)
 


### PR DESCRIPTION
Fix a forward-slash/backward-slash confusion seen
when running webassets on Windows. Basically, if the assets are in subdirs, and debug is True, then backslashes are put into URLs.

env = webassets.Environment()
bundle = webassets.Bundle("sample\\subdir\\a.css", "sample\\subdir\b.css", output="sample\\subdir\bundle.css")
env.debug = True
env.register("my_bundle", bundle)
env.directory = "."
env.url = "/my/url"
print env["my_bundle"].urls()


produces:

urls: ['/my/url/sample\\sub\\a.css', '/my/url/sample\\sub\\b.css']

This results a backslash in the URL, or "%5C". InternetExplorer deals with with, but FireFox does not.