### PR TITLE
Allow Inlining of Asset Contents

### DIFF
--- a/src/webassets/ext/jinja2.py
+++ b/src/webassets/ext/jinja2.py
@@ -142,6 +142,7 @@ class AssetsExtension(Extension):
         #
         # Summary: We have to be satisfied with a single EXTRA variable.
         args = [nodes.Name('ASSET_URL', 'store'),
+                nodes.Name('ASSET_CONTENTS', 'store'),
                 nodes.Name('EXTRA', 'store')]
 
         # Return a ``CallBlock``, which means Jinja2 will call a Python method
@@ -183,13 +184,13 @@ class AssetsExtension(Extension):
 
         # Retrieve urls (this may or may not cause a build)
         with bundle.bind(env):
-            urls = bundle.urls()
+            urls = bundle.urls_with_bodies()
 
         # For each url, execute the content of this template tag (represented
         # by the macro ```caller`` given to use by Jinja2).
         result = u""
-        for url in urls:
-            result += caller(url, bundle.extra)
+        for url, body in urls:
+            result += caller(url, body, bundle.extra)
         return result
 
 

--- a/tests/test_ext/test_jinja2.py
+++ b/tests/test_ext/test_jinja2.py
@@ -27,6 +27,7 @@ class TestTemplateTag(object):
         test_instance = self
         class MockBundle(Bundle):
             urls_to_fake = ['foo']
+            content_to_fake = ['bar']
             def __init__(self, *a, **kw):
                 Bundle.__init__(self, *a, **kw)
                 self.env = assets_env
@@ -38,6 +39,9 @@ class TestTemplateTag(object):
                 test_instance.the_bundle = self
             def urls(self, *a, **kw):
                 return self.urls_to_fake
+            def urls_with_bodies(self, *a, **kw):
+                return zip(self.urls_to_fake, self.content_to_fake)
+
         self._old_bundle_class = AssetsExtension.BundleClass
         AssetsExtension.BundleClass = self.BundleClass = MockBundle
 
@@ -87,7 +91,13 @@ class TestTemplateTag(object):
         """Ensure the tag correctly spits out the urls the bundle returns.
         """
         self.BundleClass.urls_to_fake = ['foo', 'bar']
+        self.BundleClass.content_to_fake = ['as', 'df']
         assert self.render_template('"file1" "file2" "file3"') == 'foo;bar;'
+
+    def test_asset_contents(self):
+        output = self.jinja_env.from_string(
+            '{% assets "bundle" %}{{ ASSET_CONTENTS }}{% endassets %}').render({})
+        assert output == 'bar'
 
     def test_debug_on_tag(self):
         content = self.jinja_env.from_string(


### PR DESCRIPTION
Fixes #246. This adds a `urls_with_bodies` method that is complementary to the existing `urls` method. It updates the Jinja extension to add an `ASSET_CONTENTS` variable. Tests are passing.