### PR TITLE
Allow extra option for sass filter

### DIFF
--- a/src/webassets/filter/sass.py
+++ b/src/webassets/filter/sass.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 import os, subprocess
 
 from webassets.filter import Filter
-from webassets.exceptions import FilterError, ImminentDeprecationWarning
+from webassets.exceptions import FilterError
 from webassets.cache import FilesystemCache
 
 
@@ -153,7 +153,7 @@ class Sass(Filter):
             stdout, stderr = proc.communicate(_in.read().encode('utf-8'))
 
             if proc.returncode != 0:
-                raise FilterError(('sass: subprocess had error: stderr=%s, '+
+                raise FilterError(('sass: subprocess had error: stderr=%s, ' +
                                    'stdout=%s, returncode=%s') % (
                                                 stderr, stdout, proc.returncode))
             elif stderr:
@@ -184,6 +184,6 @@ class SCSS(Sass):
     name = 'scss'
 
     def __init__(self, *a, **kw):
-        assert not 'scss' in kw
+        assert 'scss' not in kw
         kw['scss'] = True
         super(SCSS, self).__init__(*a, **kw)

--- a/src/webassets/filter/sass.py
+++ b/src/webassets/filter/sass.py
@@ -118,8 +118,10 @@ class Sass(Filter):
         if cd:
             os.chdir(cd)
 
+        binary = self.binary.split() if self.binary else 'sass'
+
         try:
-            args = [self.binary or 'sass',
+            args = binary + [
                     '--stdin',
                     '--style', self.style or 'expanded',
                     '--line-comments']

--- a/src/webassets/filter/sass.py
+++ b/src/webassets/filter/sass.py
@@ -118,7 +118,7 @@ class Sass(Filter):
         if cd:
             os.chdir(cd)
 
-        binary = self.binary.split() if self.binary else 'sass'
+        binary = self.binary.split() if self.binary else ['sass']
 
         try:
             args = binary + [


### PR DESCRIPTION
I wanted to use sass from inside a docker container.
To do this, I needed to set the *SASS_BIN* as an executable path with some options.
This patch allows to use the *SASS_BIN* with additional options.

I've only patched the sassfilter. Consider this PR as a POC. If this solution is good for you, I could extends this to other filters before merging.