### PR TITLE
show input file on filter error

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 Unreleased
     - Prevent filters from crashing if the input file is empty (empty string
       passed)
+    - Show input content on filter error
 
 0.10.1 (2014-07-03)
     - Python 3 fixes.

--- a/src/webassets/filter/__init__.py
+++ b/src/webassets/filter/__init__.py
@@ -479,6 +479,11 @@ class ExternalTool(six.with_metaclass(ExternalToolMetaclass, Filter)):
                     os.close(fd)
                 return self.filename
 
+            def read(self):
+                if self.created:
+                    with open(self.filename) as f:
+                        return f.read()
+
             @property
             def created(self):
                 return hasattr(self, 'filename')
@@ -518,9 +523,12 @@ class ExternalTool(six.with_metaclass(ExternalToolMetaclass, Filter)):
             if proc.returncode:
                 raise FilterError(
                     '%s: subprocess returned a non-success result code: '
-                    '%s, stdout=%s, stderr=%s' % (
+                    '%s, stdout=%s, stderr=%s, input_file:\n%s\n%s\n%s' % (
                         cls.name or cls.__name__, 
-                        proc.returncode, stdout, stderr))
+                        proc.returncode, stdout, stderr,
+                        '{:-^80}'.format(' input begin '),
+                        input_file.read(),
+                        '{:-^80}'.format(' input end ')))
             else:
                 if output_file.created:
                     with open(output_file.filename, 'rb') as f:


### PR DESCRIPTION
This PR shows the input file when a filter errors out. It provides extra hints to the developer to understand why the filter failed since the error message is not always obvious.

```
Traceback (most recent call last):
    env[bundle_name].build()
  File "/opt/webapp/smlib.assets/local/lib/python2.7/site-packages/webassets/bundle.py", line 663, in build
    disable_cache=disable_cache))
  File "/opt/webapp/smlib.assets/local/lib/python2.7/site-packages/webassets/bundle.py", line 600, in _build
    force, disable_cache=disable_cache, extra_filters=extra_filters)
  File "/opt/webapp/smlib.assets/local/lib/python2.7/site-packages/webassets/bundle.py", line 554, in _merge_and_apply
    return filtertool.apply(final, selected_filters, 'output')
  File "/opt/webapp/smlib.assets/local/lib/python2.7/site-packages/webassets/merge.py", line 276, in apply
    return self._wrap_cache(key, func)
  File "/opt/webapp/smlib.assets/local/lib/python2.7/site-packages/webassets/merge.py", line 218, in _wrap_cache
    content = func().getvalue()
  File "/opt/webapp/smlib.assets/local/lib/python2.7/site-packages/webassets/merge.py", line 251, in func
    getattr(filter, type)(data, out, **kwargs_final)
  File "/opt/webapp/smlib.assets/local/lib/python2.7/site-packages/webassets/filter/uglifyjs.py", line 32, in output
    self.subprocess(args, out, _in)
  File "/opt/webapp/smlib.assets/local/lib/python2.7/site-packages/webassets/filter/__init__.py", line 533, in subprocess
    '{:-^80}'.format(' input end ')))
webassets.exceptions.FilterError: uglifyjs: subprocess returned a non-success result code: 1, stdout=, stderr=Parse error at /tmp/tmpaQbl7p:2,1
Unexpected token: operator (<)
Error
    at new JS_Parse_Error (/usr/lib/node_modules/uglify-js/lib/parse.js:189:18)
    at js_error (/usr/lib/node_modules/uglify-js/lib/parse.js:197:11)
    at croak (/usr/lib/node_modules/uglify-js/lib/parse.js:656:9)
    at token_error (/usr/lib/node_modules/uglify-js/lib/parse.js:664:9)
    at unexpected (/usr/lib/node_modules/uglify-js/lib/parse.js:670:9)
    at expr_atom (/usr/lib/node_modules/uglify-js/lib/parse.js:1166:9)
    at maybe_unary (/usr/lib/node_modules/uglify-js/lib/parse.js:1327:19)
    at expr_ops (/usr/lib/node_modules/uglify-js/lib/parse.js:1362:24)
    at maybe_conditional (/usr/lib/node_modules/uglify-js/lib/parse.js:1367:20)
    at maybe_assign (/usr/lib/node_modules/uglify-js/lib/parse.js:1391:20)
, input_file:
--------------------------------- input begin ----------------------------------
React.render(
	<h1>Hello, World</h1>,
	document.getElementById('example')
);
---------------------------------- input end -----------------------------------
```