### PR TITLE
Convert CompassConfig to unicode instead of string

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,1 +1,2 @@
+#!/bin/sh
 PYTHONPATH=src/ py.test $*

--- a/src/webassets/filter/compass.py
+++ b/src/webassets/filter/compass.py
@@ -49,21 +49,18 @@ class CompassConfig(dict):
             """ Determine the correct string rep for the config file """
             if isinstance(val, bool):
                 # True -> true and False -> false
-                return str(val).lower()
+                return six.text_type(val).lower()
             elif isinstance(val, six.string_types) and val.startswith(':'):
                 # ruby symbols, like :nested, used for "output_style"
-                return str(val)
+                return six.text_type(val)
             elif isinstance(val, dict):
                 # ruby hashes, for "sass_options" for example
-                return '{%s}' % ', '.join("'%s' => '%s'" % i for i in val.items())
+                return u'{%s}' % ', '.join("'%s' => '%s'" % i for i in val.items())
             elif isinstance(val, tuple):
                 val = list(val)
-            elif isinstance(val, six.text_type) and not six.PY3:
-                # remove unicode indicator in python2 unicode string
-                return repr(val.encode('utf-8'))
             # works fine with strings and lists
             return repr(val)
-        return '\n'.join(['%s = %s' % (k, string_rep(v)) for k, v in self.items()])
+        return u'\n'.join(['%s = %s' % (k, string_rep(v)) for k, v in self.items()])
 
 
 class Compass(Filter):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1142,6 +1142,7 @@ class TestCompassConfig(object):
         'http_path': '/',
         'relative_assets': True,
         'output_style': ':nested',
+        'javascripts_dir': u'diretório_javascript',
         'sprite_load_path': [
             'static/img',
         ],
@@ -1155,6 +1156,10 @@ class TestCompassConfig(object):
 
     def setup(self):
         self.compass_config = CompassConfig(self.config).to_string()
+
+    def test_compass_config_is_unicode(self):
+        from webassets.six import text_type
+        assert isinstance(self.compass_config, text_type)
 
     def test_string_value(self):
         assert "http_path = '/'" in self.compass_config


### PR DESCRIPTION
This fixes the following:

```
  File "/home/jenkins/.virtualenvs/confidential/local/lib/python2.7/site-packages/webassets/filter/compass.py", line 206, in open
    f.write(config.to_string())
TypeError: must be unicode, not str
```