### PR TITLE
actually silence cssutils css3 warnings

### DIFF
--- a/src/webassets/filter/cssutils.py
+++ b/src/webassets/filter/cssutils.py
@@ -23,9 +23,6 @@ class CSSUtils(Filter):
         self.cssutils = cssutils
 
         try:
-            # cssutils is unaware of so many new CSS3 properties,
-            # vendor-prefixes etc., that it's diagnostic messages are rather
-            # useless. Disable them.
             log = logging.getLogger('assets.cssutils')
             log.addHandler(logging.handlers.MemoryHandler(10))
 
@@ -36,6 +33,11 @@ class CSSUtils(Filter):
             else:
                 func = cssutils.log.setlog
             func(log)
+            
+            # cssutils is unaware of so many new CSS3 properties,
+            # vendor-prefixes etc., that it's diagnostic messages are rather
+            # useless. Disable them.
+            cssutils.log.setLevel(logging.FATAL)
         except ImportError:
             # During doc generation, Django is not going to be setup and will
             # fail when the settings object is accessed. That's ok though.


### PR DESCRIPTION
Despite the comment, #e8fe4d34cd59cf5d175d54e07585c987ba765228 doesn't actually seem to silence the logging.
Setting the log level to FATAL hides the CSS3 warnings. Closes #422.

Only tested with the pelican webassets plugin, maybe someone else can try this using something else?