### PR TITLE
refactor cssutils filter initalization

### DIFF
--- a/src/webassets/filter/cssutils.py
+++ b/src/webassets/filter/cssutils.py
@@ -22,26 +22,11 @@ class CSSUtils(Filter):
         import cssutils
         self.cssutils = cssutils
 
-        try:
-            log = logging.getLogger('assets.cssutils')
-            log.addHandler(logging.handlers.MemoryHandler(10))
-
-            # Newer versions of cssutils print a deprecation warning
-            # for 'setlog'.
-            if hasattr(cssutils.log, 'setLog'):
-                func = cssutils.log.setLog
-            else:
-                func = cssutils.log.setlog
-            func(log)
-            
-            # cssutils is unaware of so many new CSS3 properties,
-            # vendor-prefixes etc., that it's diagnostic messages are rather
-            # useless. Disable them.
-            cssutils.log.setLevel(logging.FATAL)
-        except ImportError:
-            # During doc generation, Django is not going to be setup and will
-            # fail when the settings object is accessed. That's ok though.
-            pass
+        # cssutils is unaware of many new CSS3 properties,
+        # vendor-prefixes etc., and logs many non-fatal warnings
+        # about them. These diagnostic messages are rather
+        # useless, so disable everything that's non-fatal.
+        cssutils.log.setLevel(logging.FATAL)
 
     def output(self, _in, out, **kw):
         sheet = self.cssutils.parseString(_in.read())


### PR DESCRIPTION
remove try/except ImportError and change workaround for silencing cssutils
* The try/except ImportError is not needed anymore as neither a django settings object is accessed nor an import is taking
place.
* The setLog / setlog deprecation workaround is not needed anymore because even Debian wheezy ships a newer version of
cssutils.
* Raising the log level to fatal is enough to hide all of cssutil's warnings encountering CSS3.

This is a follow-up to the discussions held in #423.