### PR TITLE
Fix two small typos in docs

### DIFF
--- a/docs/script.rst
+++ b/docs/script.rst
@@ -2,7 +2,7 @@
 Command Line Interface
 ======================
 
-While it's often convienient to have webassets automatically rebuild
+While it's often convenient to have webassets automatically rebuild
 your bundles on access, you sometimes may prefer to build manually,
 for example for performance reasons in larger deployments.
 
@@ -19,7 +19,7 @@ within your framework. If that is not the case, read on.
 Build a custom command line client
 ----------------------------------
 
-In most cases, you can simple wrap around the ``webassets.script.main``
+In most cases, you can simply wrap around the ``webassets.script.main``
 function. For example, the command provided by Flask-Assets looks like
 this:
 


### PR DESCRIPTION
Correct spelling of "convenient", and "simple wrap" to "simply wrap".