### PR TITLE
Avoid overwriting settings by storing them separately on the configuration context

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,43 +1,46 @@
 language: python
-python:
-  - 2.6
+python: 2.7
+sudo: false
 install: 
-  # Supposed to help get PIL to install on PyPi
-  # https://github.com/python-imaging/Pillow/issues/570
-  - sudo apt-get install python-tk
-  
-  # To install external filter binaries, we first need to install
-  # RubyGems and Node/NPM. I'm not sure why, since it seems clear
-  # that NVM and RVM are pre-installed (see below).
-  - sudo apt-get install python-software-properties
-  - sudo apt-add-repository -y ppa:chris-lea/node.js
-  - sudo apt-get update
-  - sudo apt-get install nodejs rubygems
-  - sudo apt-get install npm
-  - npm install -g postcss autoprefixer
+  # Setup a virtualenv (to allow installing nodeenv)
+  - rm -rf py_env
+  - virtualenv py_env
+  - . py_env/bin/activate
+  - pip install nodeenv
 
-  # These are useful for debugging this mess.
-  #- env
-  #- gem env
-  #- rvm info
+  # Install and activate nodeenv (to get a current version of nodejs)
+  - rm -rf node_env
+  - source py_env/bin/activate 
+  - nodeenv node_env --node=4.0.0 --prebuilt
+  - source node_env/bin/activate
 
-  # Use non-http registry? https://github.com/n1k0/casperjs/issues/876
-  # Without this, installing doesn't work.  
-  - sudo npm config set registry http://registry.npmjs.org/
-
-  # Now install the external filter binaries, finally. 
-  # If we use sudo for this, ruby gems will not work: it seems they are
-  # then installed globally, but are then searched for in a RVM location.
-  # (Clearing GEM_HOME might be a way to fix this, if sudo where necessary).
+  # Install node requirements (inside the nodeenv)
   - sh requirements-dev.sh
 
-  # Install our test runner
+  # Install our test runner (inside the virtualenv)
   - pip install tox
 
-script: tox
-notifications:
-  email:
-    - michael@elsdoerfer.com
+env: 
+  - TOX_ENV=py27
+  - TOX_ENV=py33 
+  - TOX_ENV=py34
+  - TOX_ENV=py35
+  - TOX_ENV=pypy
+  - TOX_ENV=no-glob2
+  - TOX_ENV=external-jsmin
+script: tox -e $TOX_ENV
 branches:
   only:
     - master
+addons:
+  apt:
+    sources:
+      - deadsnakes
+    packages:
+      - python3.3
+      - python3.4
+      - python3.5
+      - python-tk
+      - python-software-properties
+      - rubygems
+      - python-virtualenv

--- a/requirements-dev-2.x.pip
+++ b/requirements-dev-2.x.pip
@@ -7,4 +7,4 @@ slimmer
 cssmin
 
 # Default rsmin package is not installable via pip
-http://michael.elsdoerfer.name/rjsmin/rjsmin-1.0.1-webassets.tar.gz
+rjsmin

--- a/requirements-dev.pip
+++ b/requirements-dev.pip
@@ -13,7 +13,6 @@ mock
 Sphinx
 
 # Libs that are needed for some features
-PyYaml
 glob2
 
 # Libs that are needed by filters.
@@ -23,7 +22,3 @@ yuicompressor
 closure
 slimit==0.8.1
 ply==3.4 # https://github.com/rspivak/slimit/issues/76
-libsass==0.8.3
-
-# Python libs that requiring manual installation
-#cssprefixer

--- a/requirements-dev.sh
+++ b/requirements-dev.sh
@@ -18,3 +18,5 @@ npm install -g stylus
 npm install -g handlebars
 npm install -g typescript
 npm install -g requirejs@2.1.11
+npm install -g autoprefixer
+npm install -g postcss-cli

--- a/src/webassets/script.py
+++ b/src/webassets/script.py
@@ -95,16 +95,7 @@ class BuildCommand(Command):
             # TODO: Reset again (refactor commands to be classes)
             self.environment.debug = False
 
-        # TODO: Oh how nice it would be to use the future options stack.
         if manifest is not None:
-            try:
-                manifest = get_manifest(manifest, env=self.environment)
-            except ValueError:
-                manifest = get_manifest(
-                    # abspath() is important, or this will be considered
-                    # relative to Environment.directory.
-                    "file:%s" % os.path.abspath(manifest),
-                    env=self.environment)
             self.environment.manifest = manifest
 
         # Use output as a dict.

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,10 @@ deps26 =
 deps3 =
     -r{toxinidir}/requirements-dev.pip
 
+[testenv:py35]
+basepython = python3.5
+deps =
+    {[base]deps3}
 
 [testenv:py33]
 basepython = python3.3
@@ -68,11 +72,3 @@ deps =
     pytest==2.5.2
     mock==0.8.0
     jsmin==2.0.2
-
-[testenv:external-rjsmin]
-basepython = python2.7
-deps =
-    nose==1.0.0
-    pytest==2.5.2
-    mock==0.8.0
-    http://michael.elsdoerfer.name/rjsmin/rjsmin-1.0.1-webassets.tar.gz


### PR DESCRIPTION
I've gone ahead and changed the way ConfigurationContext stores its cache, manifest, updater and versioner so it doesn't have to overwrite settings variables, which can cause a lot of confusion when debugging ("Why is my boolean variable suddenly an instance of some class I've never header of?").

I had to move the support for absolute paths in manifests (I think?) from scripts.py to the ConfigurationContext, which I think is the more correct behaviour, but I don't completely understand what that code does, so it'd be good if you could double-check it.

I need this to be able to update the settings handling in django-assets, I hope this doesn't affect any of the other framework integrations. 

To make this run on my travis I also had to completely take apart the travis configuration. A lot of requirements seemed to be not necessary anymore to make the tests pass, so I've removed them, it's quite possible though that they're needed for local development that I didn't touch. Let me know if that's the case and I'll try and restore them.

Some of them caused trouble, libsass for example needs to be compiled (which travis doesn't like on the new docker containers). 
