### PR TITLE
max_debug_level = None for Autoprefixer filters #436

### DIFF
--- a/src/webassets/filter/autoprefixer.py
+++ b/src/webassets/filter/autoprefixer.py
@@ -42,6 +42,8 @@ class AutoprefixerFilter(ExternalTool):
         'extra_args': 'AUTOPREFIXER_EXTRA_ARGS',
     }
 
+    max_debug_level = None
+
     def input(self, in_, out, source_path, **kw):
         # Set working directory to the source file so that includes are found
         args = [self.autoprefixer or 'autoprefixer']
@@ -65,6 +67,8 @@ class Autoprefixer6Filter(AutoprefixerFilter):
     }
 
     _postcss_autoprefixer = ['-u', 'autoprefixer']
+
+    max_debug_level = None    
 
     def input(self, in_, out, source_path, **kw):
         # Set working directory to the source file so that includes are found


### PR DESCRIPTION
Setting `max_debug_level` to `None` by default will run the filter while webassets debug flag is turned on.  That way, vendor extensions are added to css for testing in different browsers during development.