### PR TITLE
Add new cache_file_mode setting and wire it up to the FileSystemCache

### DIFF
--- a/src/webassets/cache.py
+++ b/src/webassets/cache.py
@@ -167,8 +167,9 @@ class FilesystemCache(BaseCache):
 
     V = 2   # We have changed the cache format once
 
-    def __init__(self, directory):
+    def __init__(self, directory, new_file_mode=None):
         self.directory = directory
+        self.new_file_mode = new_file_mode
 
     def __eq__(self, other):
         """Return equality with the config values
@@ -205,6 +206,10 @@ class FilesystemCache(BaseCache):
             with os.fdopen(fd, 'wb') as f:
                 pickle.dump(data, f)
                 f.flush()
+            # If a non default mode is specified, then chmod the file to
+            # it before renaming it into place
+            if self.new_file_mode is not None:
+                os.chmod(temp_filename, self.new_file_mode)
             if os.path.isfile(filename):
                 os.unlink(filename)
             os.rename(temp_filename, filename)
@@ -231,4 +236,4 @@ def get_cache(option, ctx):
             os.makedirs(directory)
     else:
         directory = option
-    return FilesystemCache(directory)
+    return FilesystemCache(directory, ctx.cache_file_mode)

--- a/src/webassets/env.py
+++ b/src/webassets/env.py
@@ -392,7 +392,8 @@ class BundleRegistry(object):
 # filter setting might be CSSMIN_BIN.
 env_options = [
     'directory', 'url', 'debug', 'cache', 'updater', 'auto_build',
-    'url_expire', 'versions', 'manifest', 'load_path', 'url_mapping']
+    'url_expire', 'versions', 'manifest', 'load_path', 'url_mapping',
+    'cache_file_mode' ]
 
 
 class ConfigurationContext(object):
@@ -430,6 +431,23 @@ class ConfigurationContext(object):
             files.
         *"merge"*
             Merge the source files, but do not apply filters.
+    """)
+
+    def _set_cache_file_mode(self, mode):
+        self._storage['cache_file_mode'] = mode
+    def _get_cache_file_mode(self):
+        return self._storage['cache_file_mode']
+    cache_file_mode = property(_get_cache_file_mode, _set_cache_file_mode, doc=
+    """Controls the mode of files created in the cache. The default mode
+    is 0600.  Follows standard unix mode.
+    Possible values are any unix mode, e.g.:
+
+      ``0660``
+          Enable the group read+write bits
+
+      ``0666``
+          Enable world read+write bits
+
     """)
 
     def _set_cache(self, enable):
@@ -708,6 +726,7 @@ class BaseEnvironment(BundleRegistry, ConfigurationContext):
         self.config.setdefault('load_path', [])
         self.config.setdefault('url_mapping', {})
         self.config.setdefault('resolver', self.resolver_class())
+        self.config.setdefault('cache_file_mode', None)
 
         self.config.update(config)
 

--- a/src/webassets/loaders.py
+++ b/src/webassets/loaders.py
@@ -194,6 +194,7 @@ class YAMLLoader(object):
             # Load environment settings
             for setting in ('debug', 'cache', 'versions', 'url_expire',
                             'auto_build', 'url', 'directory', 'manifest', 'load_path',
+                            'cache_file_mode',
                             # TODO: The deprecated values; remove at some point
                             'expire', 'updater'):
                 if setting in obj:


### PR DESCRIPTION
- This mode is used to override the default mode of 0600 in the tempfile
module. See Issue #371
- Expose the setting to the YAMLLoader