### PR TITLE
Make sass plugin use paths relative to Environment.directory

### DIFF
--- a/src/webassets/filter/sass.py
+++ b/src/webassets/filter/sass.py
@@ -121,6 +121,9 @@ class Sass(Filter):
     }
     max_debug_level = None
 
+    def resolve_path(self, path):
+        return self.ctx.resolver.resolve_source(self.ctx, path)
+
     def _apply_sass(self, _in, out, cd=None):
         # Switch to source file directory if asked, so that this directory
         # is by default on the load path. We could pass it via -I, but then
@@ -149,9 +152,17 @@ class Sass(Filter):
         if self.use_compass:
             args.append('--compass')
         for path in self.load_paths or []:
-            args.extend(['-I', path])
+            if os.path.isabs(path):
+                abs_path = path
+            else:
+                abs_path = self.resolve_path(path)
+            args.extend(['-I', abs_path])
         for lib in self.libs or []:
-            args.extend(['-r', lib])
+            if os.path.isabs(lib):
+                abs_path = lib
+            else:
+                abs_path = self.resolve_path(lib)
+            args.extend(['-r', abs_path])
 
         proc = subprocess.Popen(args,
                                 stdin=subprocess.PIPE,

--- a/src/webassets/filter/sass.py
+++ b/src/webassets/filter/sass.py
@@ -101,6 +101,30 @@ class Sass(Filter):
 
         Enabled by default. To disable, set empty environment variable
         ``SASS_LINE_COMMENTS=`` or pass ``line_comments=False`` to this filter.
+
+    SASS_AS_OUTPUT
+        By default, this works as an "input filter", meaning ``sass`` is
+        called for each source file in the bundle. This is because the
+        path of the source file is required so that @import directives
+        within the Sass file can be correctly resolved.
+
+        However, it is possible to use this filter as an "output filter",
+        meaning the source files will first be concatenated, and then the
+        Sass filter is applied in one go. This can provide a speedup for
+        bigger projects.
+
+        It will also allow you to share variables between files.
+
+    SASS_LOAD_PATHS
+        It should be a list of paths relatives to Environment.directory or absolute paths.
+        Order matters as sass will pick the first file found in path order.
+        These are fed into the -I flag of the sass command and
+        is used to control where sass imports code from.
+
+    SASS_LIBS
+        It should be a list of paths relatives to Environment.directory or absolute paths.
+        These are fed into the -r flag of the sass command and
+        is used to require ruby libraries before running sass.
     """
     # TODO: If an output filter could be passed the list of all input
     # files, the filter might be able to do something interesting with

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -992,7 +992,7 @@ class TestSass(TempEnvironmentHelper):
         """Test a custom include_path.
         """
         sass_output = get_filter('sass', debug_info=False, as_output=True,
-                                 load_paths=[self.path('includes')])
+                                 load_paths=['includes'])
         self.create_files({
             'includes/vars.sass': '$a_color: #FFFFFF',
             'base.sass': '@import vars.sass\nh1\n  color: $a_color'})


### PR DESCRIPTION
I noticed the sass plugin wasn't resolving directories relative to the environment like the less plugin does. I went ahead and ported the resolve_path strategy from less into sass. 

And also some of the config options were missing from the doc string.