### PR TITLE
Allowing custom filters to be specified in YAML

### DIFF
--- a/docs/custom_filters.rst
+++ b/docs/custom_filters.rst
@@ -139,6 +139,17 @@ the filter. First, you need to register the class with the system though:
     from webassets.filter import register_filter
     register_filter(NoopFilter)
 
+Or if you are using yaml then use the filters key for the environment:
+
+.. code-block:: yaml
+
+    directory: .
+    url: /
+    debug: True
+    updater: timestamp
+    filters:
+        - my_custom_package.my_filter
+
 After that, you can use the filter like you would any of the built-in ones:
 
 .. code-block:: django

--- a/requirements-dev.pip
+++ b/requirements-dev.pip
@@ -24,6 +24,7 @@ closure
 slimit==0.8.1
 ply==3.4 # https://github.com/rspivak/slimit/issues/76
 libsass==0.8.3
+zope.dottedname
 
 # Python libs that requiring manual installation
 #cssprefixer

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -1,11 +1,13 @@
 from __future__ import with_statement
 import sys
-from nose.tools import assert_raises
+from nose.tools import assert_raises, assert_true
 import textwrap
 from webassets.env import Environment
+from webassets.filter import Filter, get_filter
 from webassets.utils import StringIO
 from webassets.bundle import Bundle
 from webassets.loaders import PythonLoader, YAMLLoader, LoaderError
+from webassets.exceptions import EnvironmentError
 from nose import SkipTest
 
 
@@ -186,3 +188,80 @@ class TestPython(object):
         assert loader3.environment == "assets"
         env3 = loader3.load_environment()
         assert env3 == module2.assets
+
+class TestYAMLCustomFilters(TestYAML):
+
+    def setup(self):
+        super(TestYAMLCustomFilters, self).setup()
+
+        # If zope.dottedname is not installed, that's OK
+        try:
+            import zope.dottedname.resolve
+        except ImportError:
+            raise SkipTest()
+        # Save off the original get_import_resolver
+        self.original_resolver = YAMLLoader._get_import_resolver
+        # Make a mock
+        def mock(cls):
+            raise ImportError
+        self.mock_resolver = mock
+
+    def mock_importer(self):
+        """ Mock the import resolver to a fake one that raises import error.
+        Be sure to call reset_importer if you use this at the beginning of
+        any test."""
+        YAMLLoader._get_import_resolver = self.mock_resolver
+
+    def reset_importer(self):
+        """ Reset the import resolver to the default one """
+        YAMLLoader._get_import_resolver = self.original_resolver
+
+    def test_cant_import_zope_is_fine(self):
+        """ Check that a YAML file without filters is fine if the import of
+        zope.dottedname fails """
+        self.mock_importer()
+        self.loader("""foo: bar""").load_environment()
+        self.reset_importer()
+
+    def test_need_zope_to_have_filter(self):
+        """ Check that we get an error if the zope.dottedname module is not
+        installed and they try to use custom filters """
+        self.mock_importer()
+        loader =  self.loader("""
+        filters:
+            - webassets.filter.less.Less
+        """)
+        assert_raises(EnvironmentError, loader.load_environment)
+        self.reset_importer()
+
+    def test_load_filter_module_throws_exc(self):
+        """ Check that passing dotted module path throws an exception """
+        # Try to load based on module name, instead of the class
+        loader =  self.loader("""
+        filters:
+            - webassets.filter.less
+        """)
+        assert_raises(LoaderError, loader.load_environment)
+
+    def test_bad_filter_throws_exc(self):
+        """ Test that importing filters that don't exist throws an exception """
+        loader =  self.loader("""
+        filters:
+            - webassets.fake.filter
+        """)
+        assert_raises(LoaderError, loader.load_environment)
+
+    def test_load_filters(self):
+        """Check that filters can be loaded from YAML """
+        # Delete the less filter
+        import webassets.filter
+        del webassets.filter._FILTERS['less']
+        # Verify that it was deleted
+        assert_raises(ValueError, get_filter, 'less')
+        # Load it again from YAML
+        self.loader("""
+        filters:
+            - webassets.filter.less.Less
+        """).load_environment()
+        # Check that it's back
+        assert_true(isinstance(get_filter('less'), Filter))


### PR DESCRIPTION
Seems like you're kinda stuck right now if you're using the YAML file approach to load your environment with the native webassets command line script and you want to start using custom filters.

This patch enables a new 'filters' key in the YAML file which is a list that gets processed as a python dotted name with zope.dottedname.resolve.

Doc changes and tests included.