### PR TITLE
More helpful error if sass not found

### DIFF
--- a/src/webassets/filter/sass.py
+++ b/src/webassets/filter/sass.py
@@ -188,14 +188,17 @@ class Sass(Filter):
                 abs_path = self.resolve_path(lib)
             args.extend(['-r', abs_path])
 
-        proc = subprocess.Popen(args,
-                                stdin=subprocess.PIPE,
-                                stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE,
-                                # shell: necessary on windows to execute
-                                # ruby files, but doesn't work on linux.
-                                shell=(os.name == 'nt'),
-                                cwd=child_cwd)
+        try:
+            proc = subprocess.Popen(args,
+                                    stdin=subprocess.PIPE,
+                                    stdout=subprocess.PIPE,
+                                    stderr=subprocess.PIPE,
+                                    # shell: necessary on windows to execute
+                                    # ruby files, but doesn't work on linux.
+                                    shell=(os.name == 'nt'),
+                                    cwd=child_cwd)
+        except OSError:
+            raise FilterError('Program file not found: %s.' % args[0])
         stdout, stderr = proc.communicate(_in.read().encode('utf-8'))
 
         if proc.returncode != 0:

--- a/src/webassets/filter/sass.py
+++ b/src/webassets/filter/sass.py
@@ -1,15 +1,14 @@
 from __future__ import print_function
 import os, subprocess
 
-from webassets.filter import Filter
-from webassets.exceptions import FilterError, ImminentDeprecationWarning
+from webassets.filter import ExternalTool
 from webassets.cache import FilesystemCache
 
 
 __all__ = ('Sass', 'SCSS')
 
 
-class Sass(Filter):
+class Sass(ExternalTool):
     """Converts `Sass <http://sass-lang.com/>`_ markup to real CSS.
 
     Requires the Sass executable to be available externally. To install
@@ -188,27 +187,7 @@ class Sass(Filter):
                 abs_path = self.resolve_path(lib)
             args.extend(['-r', abs_path])
 
-        try:
-            proc = subprocess.Popen(args,
-                                    stdin=subprocess.PIPE,
-                                    stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE,
-                                    # shell: necessary on windows to execute
-                                    # ruby files, but doesn't work on linux.
-                                    shell=(os.name == 'nt'),
-                                    cwd=child_cwd)
-        except OSError:
-            raise FilterError('Program file not found: %s.' % args[0])
-        stdout, stderr = proc.communicate(_in.read().encode('utf-8'))
-
-        if proc.returncode != 0:
-            raise FilterError(('sass: subprocess had error: stderr=%s, '+
-                               'stdout=%s, returncode=%s') % (
-                                            stderr, stdout, proc.returncode))
-        elif stderr:
-            print("sass filter has warnings:", stderr)
-
-        out.write(stdout.decode('utf-8'))
+        return self.subprocess(args, out, _in)
 
     def input(self, _in, out, source_path, output_path, **kw):
         if self.as_output:


### PR DESCRIPTION
Python subprocess module doesn't give a great error when a program is not found:

    OSError: [Errno 2] No such file or directory

so I borrowed the approach used in the babel filter, which makes the error message much nicer:

    webassets.exceptions.FilterError: Program file not found: sass.

Cc: @aconrad, @bszonye