### PR TITLE
set process in jade filter every setup()

### DIFF
--- a/src/webassets/filter/jade.py
+++ b/src/webassets/filter/jade.py
@@ -73,7 +73,7 @@ class Jade(Filter):
         """
         super(Jade, self).setup()
 
-        self.argv.append(self.jade or 'jade')
+        self.argv = [self.jade or 'jade']
         self.argv.append('--client')
 
         if self.jade_no_debug:


### PR DESCRIPTION
as per https://github.com/miracle2k/webassets/blob/master/src/webassets/filter/__init__.py#L246:

```
def setup(self):
"""
Note: This may be called multiple times if one filter instance
is used with different asset environment instances.
"""
...
```

If setup is called multiple times, this change means the Jade Filter object will have the same arguments to run every time.
