### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ Asset management application for Python web development - use it to
 merge and compress your JavaScript and CSS files.
 
 Documentation: |travis|
-        http://webassets.readthedocs.org/
+        https://webassets.readthedocs.io/
 
         Since releases aren't exactly happening on a regular schedule, you are
         encouraged to use the latest code. ``webassets`` is pretty well tested,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,8 +25,8 @@ the respective page:
 .. toctree::
    :maxdepth: 1
 
-   With Django <http://django-assets.readthedocs.org/en/latest/>
-   With Flask <http://flask-assets.readthedocs.org/en/latest/>
+   With Django <https://django-assets.readthedocs.io/en/latest/>
+   With Flask <https://flask-assets.readthedocs.io/en/latest/>
    With Pyramid <https://github.com/sontek/pyramid_webassets>
    Other or no framework <generic/index>
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.