### PR TITLE
Made sure to close out the sourcemap_file

### DIFF
--- a/src/webassets/filter/compass.py
+++ b/src/webassets/filter/compass.py
@@ -242,6 +242,7 @@ class Compass(Filter):
                     os.mkdir(path.dirname(sourcemap_output_filepath))
                 sourcemap_output_file = open(sourcemap_output_filepath, 'w')
                 sourcemap_output_file.write(sourcemap_file.read())
+                sourcemap_file.close()
             try:
                 contents = output_file.read()
                 out.write(contents)


### PR DESCRIPTION
The temp dir can't be removed because the sourcemap_file is busy due to it being read for the sourcemap_output_file. Just needs to be closed.