### PR TITLE
Fix invalid Python syntax in css_compilers.rst

### DIFF
--- a/docs/css_compilers.rst
+++ b/docs/css_compilers.rst
@@ -34,7 +34,7 @@ child bundle:
 
 .. code-block:: python
 
-    sass = Bundle('*.sass' filters='sass', output='gen/sass.css')
+    sass = Bundle('*.sass', filters='sass', output='gen/sass.css')
     all_css = Bundle('css/jquery.calendar.css', sass,
                      filters='cssmin', output="gen/all.css")
 


### PR DESCRIPTION
Adds a missing comma