### PR TITLE
pyinstaller support

### DIFF
--- a/src/webassets/filter/__init__.py
+++ b/src/webassets/filter/__init__.py
@@ -694,9 +694,26 @@ def load_builtin_filters():
     from os import path
     import warnings
 
-    #current_dir = path.dirname(__file__)
-    #for name in unique_modules(current_dir):
-    for loader, module_name, ispkg in pkgutil.iter_modules(__path__, __name__ + '.'):
+    # load modules to work based with and without pyinstaller
+    # from: https://github.com/webcomics/dosage/blob/master/dosagelib/loader.py
+    # see: https://github.com/pyinstaller/pyinstaller/issues/1905
+
+    # load modules using iter_modules()
+    # (should find all filters in normal build, but not pyinstaller)
+    prefix = __name__ + '.'
+    module_names = [m[1] for m in pkgutil.iter_modules(__path__, prefix)]
+
+    # special handling for PyInstaller
+    importers = map(pkgutil.get_importer, __path__)
+    toc = set()
+    for i in importers:
+        if hasattr(i, 'toc'):
+            toc |= i.toc
+    for elm in toc:
+        if elm.startswith(prefix):
+            module_names.append(elm)
+
+    for module_name in module_names:
         #module_name = 'webassets.filter.%s' % name
         try:
             module = import_module(module_name)

--- a/src/webassets/filter/__init__.py
+++ b/src/webassets/filter/__init__.py
@@ -9,6 +9,7 @@ import subprocess
 import inspect
 import shlex
 import tempfile
+import pkgutil
 from webassets import six
 from webassets.six.moves import map
 from webassets.six.moves import zip
@@ -693,10 +694,10 @@ def load_builtin_filters():
     from os import path
     import warnings
 
-    current_dir = path.dirname(__file__)
-    for name in unique_modules(current_dir):
-
-        module_name = 'webassets.filter.%s' % name
+    #current_dir = path.dirname(__file__)
+    #for name in unique_modules(current_dir):
+    for loader, module_name, ispkg in pkgutil.iter_modules(__path__, __name__ + '.'):
+        #module_name = 'webassets.filter.%s' % name
         try:
             module = import_module(module_name)
         except Exception as e:


### PR DESCRIPTION
This PR allows webassets to be included in an executable built with [Pyinstaller](http://www.pyinstaller.org/)

Without this, `import webassets` crashes on `os.listdir` as the directory doesn't exist.

This provides an alternative method for finding the filters that works with and without pyinstaller.

This will allow webassets to not crash when included.

To include the filters with pyinstaller, a custom `hooks-webassets.py` is also used to specify the filters:

```
from PyInstaller.utils.hooks import collect_submodules

hiddenimports = collect_submodules('webassets.filter')
```

My use case is specifically to build all bundles beforehand, and include only the output files in the standalone exe. As such, I also use a custom `FixedBundle` subclass that just uses the output

```
class FixedBundle(Bundle):
    def urls(self, *a, **kw):
        ctx = wrap(self.env, self)
        urls = []
        for bundle, extra_filters, new_ctx in self.iterbuild(ctx):
            urls.append(ctx.url + bundle.output)

        return urls

AssetsExtension.BundleClass = FixedBundle

```

I'm including this here in case it is useful for someone else.. 
Happy to contribute this in a PR as well if it may be useful or refactor to make it more general.