### PR TITLE
Add many-to-many transformation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 /*.wpr
 # JetBrains
 /.idea
+# SublimeText
+*.sublime-*
 
 # distutils
 /build
@@ -23,3 +25,4 @@
 /envdev*
 /.virtualenv*
 /node_modules/
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ install:
   # that NVM and RVM are pre-installed (see below).
   - sudo apt-get install python-software-properties
 
-  - npm install -g postcss-cli autoprefixer
-
   # Now install the external filter binaries, finally.
   # If we use sudo for this, ruby gems will not work: it seems they are
   # then installed globally, but are then searched for in a RVM location.

--- a/AUTHORS
+++ b/AUTHORS
@@ -30,6 +30,7 @@ Iuri de Silvio <iurisilvio@gmail.com>
 Jack Riches <jack.riches@g108669mac.thisisglobal.com>
 Janne Vanhala <janne.vanhala@gmail.com>
 Javier Gonel <bolibic@gmail.com>
+Juan-Pablo Scaletti <juanpablo@jpscaletti.com>
 Jimmy Yuen Ho Wong <wyuenho@gmail.com>
 John Anderson <sontek@gmail.com>
 John Paulett <john@paulett.org>

--- a/docs/bundles.rst
+++ b/docs/bundles.rst
@@ -28,10 +28,18 @@ arguments:
   source files will merely be merged into the output file. Filters are
   applied in the order in which they are given.
 
-* ``output`` - Name/path of the output file. All source files will be merged
-  and the result stored at this location. A ``%(version)s`` placeholder is
+* ``merge`` - If ``True`` (the default), All source files will be merged
+  and the result stored at ``output``. Otherwise, each file will be
+  processed separately.
+
+* ``output`` - Name/path of the output file. A ``%(version)s`` placeholder is
   supported here, which will be replaced with the version of the file. See
   :doc:`/expiring`.
+  If ``merge`` is ``True``, this argument is required and you can also use
+  these placeholders:
+  - ``%(name)s`` Just the name of the source file, whithout path or extension (eg: 'common')
+  - ``%(path)s`` The path and name of the source file (eg: 'portal/js/common')
+  - ``%(ext)s`` The extension of source file (eg: 'js')
 
 * ``depends`` - Additional files that will be watched to determine if the 
   bundle needs to be rebuilt. This is usually necessary if you are using
@@ -101,6 +109,7 @@ Some things to consider when nesting bundles:
   an output target, it simply serves as a container of its sub-bundles,
   which in turn will be processed into their respective output files.
   In this case it must not have any files of its own.
+* A bundle with ``merge=False`` cannot contain nested bundles.
 
 
 Building bundles

--- a/requirements-dev.sh
+++ b/requirements-dev.sh
@@ -12,7 +12,9 @@ set -e
 # Only install NodeJS version by default.
 #gem install less --version 1.2.21
 
-npm install -g less@2.5.1
+npm install -g postcss-cli
+npm install -g autoprefixer
+npm install -g less
 npm install -g uglify-js@2.3.1
 npm install -g coffee-script@1.6.2
 npm install -g clean-css@1.0.2
@@ -20,7 +22,7 @@ npm install -g stylus
 npm install -g handlebars
 npm install -g typescript
 npm install -g requirejs@2.1.11
-npm install -g babel-cli@6.18.0
+npm install -g babel-cli@6.18.0 --save
 # Don't install the babel-preset globally because
 # there's a bug with older verisons of node
-npm install babel-preset-es2015@6.18.0 --save
+npm install babel-preset-es2015@6.18.0

--- a/src/webassets/bundle.py
+++ b/src/webassets/bundle.py
@@ -117,6 +117,7 @@ class Bundle(object):
         self.version = options.pop('version', [])
         self.remove_duplicates = options.pop('remove_duplicates', True)
         self.extra = options.pop('extra', {})
+        self.merge = options.pop('merge', True)
 
         self._config = BundleConfig(self)
         self._config.update(options.pop('config', {}))


### PR DESCRIPTION
It does so by automatically decomposing a Bundle with `merge=False` in one Bundle for
each file.

Example:

```python
environment.register(
	'styles', '*.scss',
	merge=False, filters='scss',
	output='build/%(name)s.%(version)s.css'
)
```

wil be transformed to

```python
environment.register(
    'styles/file1.scss', 'file1.scss',
    filters='scss',
    output='build/file1.%(version)s.css'
)
environment.register(
    'styles/file2.scss', 'file2.scss',
    filters='scss',
    output='build/file2.%(version)s.css'
)
environment.register(
    'styles/file3.scss', 'file3.scss',
    filters='scss',
    output='build/file3.%(version)s.css'
)
```

When `merge` is `False` in addition to `%(version)s` you can use the placeholders:
- `%(name)s` (the name without the original extension)
- `%(path)s` (path and filename without extension) and
- `%(ext)s` (just the extension)