### PR TITLE
Pass --filename to babel to allow use of babelrc

### DIFF
--- a/src/webassets/filter/babel.py
+++ b/src/webassets/filter/babel.py
@@ -1,5 +1,6 @@
 from webassets.filter import ExternalTool
 
+
 class Babel(ExternalTool):
     """Processes ES6+ code into ES5 friendly code using `Babel <https://babeljs.io/>`_.
 
@@ -70,5 +71,7 @@ class Babel(ExternalTool):
             args += ['--presets', self.presets]
         if self.extra_args:
             args.extend(self.extra_args)
+        if 'source_path' in kw:
+            args.extend(['--filename', kw['source_path']])
         return self.subprocess(args, out, _in)
 


### PR DESCRIPTION
See https://github.com/babel/babel/issues/5297 for some rough
 details.

This allows more complicated use of babel without passing a
 big mess of extra_args.

This also resolves package.json for babel as well