### PR TITLE
Remove ``--allow-all-external``

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [testenv]
 commands = py.test {posargs:tests}
-install_command = pip install --allow-all-external --pre {opts} {packages}
+install_command = pip install --pre {opts} {packages}
 
 #*************************************************************************
 # Test various runtimes.


### PR DESCRIPTION
It's been removed in Pip version 10 and was deprecated (and no-oped) in
version 8