### PR TITLE
Correct argument name in Environment docs

### DIFF
--- a/src/webassets/env.py
+++ b/src/webassets/env.py
@@ -684,7 +684,7 @@ class ConfigurationContext(object):
                 'The environment has no "directory" configured')
     directory = property(_get_directory, _set_directory, doc=
     """The base directory to which all paths will be relative to,
-    unless :attr:`load_paths` are given, in which case this will
+    unless :attr:`load_path` are given, in which case this will
     only serve as the output directory.
 
     In the url space, it is mapped to :attr:`urls`.
@@ -845,4 +845,3 @@ def parse_debug_value(value):
         return 'merge'
     else:
         raise ValueError()
-


### PR DESCRIPTION
Currently `Environment.directory` docs refer to `load_paths`(this name is used in filter's argument) whereas Environment's config is named as `load_path`