### PR TITLE
Lock on building bundles with the same output target

### DIFF
--- a/src/webassets/lockmanager.py
+++ b/src/webassets/lockmanager.py
@@ -1,0 +1,22 @@
+from threading import Lock
+
+
+class LockManager(object):
+    """Implementation of a manager that returns a lock based on a given key
+    ``get_lock`` uses a lock to prevent multiple threads from entering it
+    at the same time
+    """
+    def __init__(self):
+        self.__locks = dict()
+        self.__check_lock = Lock()
+
+    def get_lock(self, key):
+        """Returns the lock corresponding to the given key
+        """
+        with self.__check_lock:
+            if key in self.__locks:
+                return self.__locks[key]
+            else:
+                lock = Lock()
+                self.__locks[key] = lock
+                return lock


### PR DESCRIPTION
I ran into problems with the autobuild starting the build progress so often that the server ran out of memory (from all the node instances).
So here is my solution to preventing this from happening