### PR TITLE
Sub-resource integrity

### DIFF
--- a/src/webassets/bundle.py
+++ b/src/webassets/bundle.py
@@ -820,6 +820,12 @@ class Bundle(object):
 
         Insofar necessary, this will automatically create or update the files
         behind these urls.
+
+        :param calculate_sri: Set to true to calculate a sub-resource integrity
+        string for the URLs. This changes the returned format.
+
+        :return: List of URIs if calculate_sri is False. If calculate_sri is
+                 true: list of {'uri': '<uri>', 'sri': '<sri-hash>'}.
         """
         ctx = wrap(self.env, self)
         urls = []

--- a/src/webassets/ext/jinja2.py
+++ b/src/webassets/ext/jinja2.py
@@ -142,6 +142,7 @@ class AssetsExtension(Extension):
         #
         # Summary: We have to be satisfied with a single EXTRA variable.
         args = [nodes.Name('ASSET_URL', 'param'),
+                nodes.Name('ASSET_SRI', 'param'),
                 nodes.Name('EXTRA', 'param')]
 
         # Return a ``CallBlock``, which means Jinja2 will call a Python method
@@ -177,6 +178,7 @@ class AssetsExtension(Extension):
             'filters': filter,
             'debug': dbg,
             'depends': depends,
+            'calculate_sri': True,
         }
         bundle = self.BundleClass(
             *self.resolve_contents(files, env), **bundle_kwargs)
@@ -188,8 +190,11 @@ class AssetsExtension(Extension):
         # For each url, execute the content of this template tag (represented
         # by the macro ```caller`` given to use by Jinja2).
         result = u""
-        for url in urls:
-            result += caller(url, bundle.extra)
+        for entry in urls:
+            if isinstance(entry, dict):
+                result += caller(entry['uri'], entry.get('sri', None), bundle.extra)
+            else:
+                result += caller(entry, None, bundle.extra)
         return result
 
 

--- a/src/webassets/ext/jinja2.py
+++ b/src/webassets/ext/jinja2.py
@@ -177,15 +177,14 @@ class AssetsExtension(Extension):
             'output': output,
             'filters': filter,
             'debug': dbg,
-            'depends': depends,
-            'calculate_sri': True,
+            'depends': depends
         }
         bundle = self.BundleClass(
             *self.resolve_contents(files, env), **bundle_kwargs)
 
         # Retrieve urls (this may or may not cause a build)
         with bundle.bind(env):
-            urls = bundle.urls()
+            urls = bundle.urls(calculate_sri=True)
 
         # For each url, execute the content of this template tag (represented
         # by the macro ```caller`` given to use by Jinja2).

--- a/src/webassets/utils.py
+++ b/src/webassets/utils.py
@@ -36,6 +36,14 @@ else:
     set = set
 
 
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = IOError
+else:
+    FileNotFoundError = FileNotFoundError
+
+
 from webassets.six import StringIO
 
 
@@ -214,16 +222,28 @@ def is_url(s):
     return bool(parsed.scheme and parsed.netloc) and len(parsed.scheme) > 1
 
 
-def calculate_sri(input):
-    """Calculate SRI string"""
-    BUF_SIZE = 65536
+def calculate_sri(data):
+    """Calculate SRI string for data buffer."""
     hash = hashlib.sha384()
-    with open(input, 'rb') as f:
-        while True:
-            data = f.read(BUF_SIZE)
-            if not data:
-                break
-            hash.update(data)
+    hash.update(data)
     hash = hash.digest()
     hash_base64 = base64.b64encode(hash).decode()
     return 'sha384-{}'.format(hash_base64)
+
+
+def calculate_sri_on_file(file_name):
+    """Calculate SRI string if file can be found. Otherwise silently return None"""
+    BUF_SIZE = 65536
+    hash = hashlib.sha384()
+    try:
+        with open(file_name, 'rb') as f:
+            while True:
+                data = f.read(BUF_SIZE)
+                if not data:
+                    break
+                hash.update(data)
+        hash = hash.digest()
+        hash_base64 = base64.b64encode(hash).decode()
+        return 'sha384-{}'.format(hash_base64)
+    except FileNotFoundError:
+        return None

--- a/src/webassets/utils.py
+++ b/src/webassets/utils.py
@@ -12,6 +12,8 @@ __all__ = ('md5_constructor', 'pickle', 'set', 'StringIO',
            'common_path_prefix', 'working_directory', 'is_url')
 
 
+import base64
+
 if sys.version_info >= (2, 5):
     import hashlib
     md5_constructor = hashlib.md5
@@ -210,3 +212,18 @@ def is_url(s):
         return False
     parsed = urlparse.urlsplit(s)
     return bool(parsed.scheme and parsed.netloc) and len(parsed.scheme) > 1
+
+
+def calculate_sri(input):
+    """Calculate SRI string"""
+    BUF_SIZE = 65536
+    hash = hashlib.sha384()
+    with open(input, 'rb') as f:
+        while True:
+            data = f.read(BUF_SIZE)
+            if not data:
+                break
+            hash.update(data)
+    hash = hash.digest()
+    hash_base64 = base64.b64encode(hash).decode()
+    return 'sha384-{}'.format(hash_base64)


### PR DESCRIPTION
This pull request implements #494, by adding a flag to the Bundle.urls() method (calculate_sri) that defaults to false. When set to true it changes the return value from a list of URIs to a list of (using syntax based on Python 3's typing module):
```python
{'uri': str, sri: Optional[str]}
```

For example:
```python
[{'uri': '/a',
  'sri': 'sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb'}]
```

This is then used by the jinja2 module to expose a new variable ASSERT_SRI. that can be used something like this:
```jinja2
{%- assets filters="cssutils", output="css/min.css", "css/reset.css", "css/site.css" -%}
    <link rel="stylesheet" href="{{ ASSET_URL }}" integrity="{{ ASSET_SRI }}">
{%- endassets -%}
```

Note that the SRI is not computed for remote resources, in that case None is returned. This should be handled properly, but obviously it is something that the template write will have to deal with if it can happen in their environment (and they also want to use the integrity features for local resources).

This could be extended in the future to download and calculate the hash for remote resources, but there is an inherent trust/security issue, should that resource change between builds when you don't expect it to, so I'm not sure it would be a good idea.

This has been tested on Python 2.7 and 3.7, I do not have easy ability to test anything else, and there seems to be some issue with failing unit tests in general for this project in the Travis CI setup.
