### PR TITLE
New scss filter

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+Unreleased
+    - Make the `sass` and `scss` filters compatible with the reference compiler
+    - Add new `sass_ruby` and `scss_ruby` filters to use the deprecated Ruby Sass compiler
+
 0.12.1 (2017-01-08)
     - Fix compatibility with Jinja 2.9.
     - When globbing, include files in alphabetical order (Sam Douglas).

--- a/docs/builtin_filters.rst
+++ b/docs/builtin_filters.rst
@@ -149,6 +149,18 @@ JS/CSS compilers
 .. autoclass:: webassets.filter.sass.SCSS
 
 
+``ruby_sass``
+~~~~~~~~
+
+.. autoclass:: webassets.filter.sass.RubySass
+
+
+``ruby_scss``
+~~~~~~~~
+
+.. autoclass:: webassets.filter.sass.RubySCSS
+
+
 ``compass``
 ~~~~~~~~~~~
 

--- a/requirements-dev.sh
+++ b/requirements-dev.sh
@@ -15,6 +15,7 @@ set -e
 npm install -g postcss-cli
 npm install -g autoprefixer
 npm install -g less
+npm install -g sass
 npm install -g uglify-js@2.3.1
 npm install -g coffee-script@1.6.2
 npm install -g clean-css@1.0.2

--- a/src/webassets/filter/__init__.py
+++ b/src/webassets/filter/__init__.py
@@ -524,7 +524,9 @@ class ExternalTool(six.with_metaclass(ExternalToolMetaclass, Filter)):
                     '%s: subprocess returned a non-success result code: '
                     '%s, stdout=%s, stderr=%s' % (
                         cls.name or cls.__name__,
-                        proc.returncode, stdout, stderr))
+                        proc.returncode,
+                        stdout.decode('utf-8').strip(),
+                        stderr.decode('utf-8').strip()))
             else:
                 if output_file.created:
                     with open(output_file.filename, 'rb') as f:


### PR DESCRIPTION
This PR implements the changes requested to #516 in https://github.com/miracle2k/webassets/pull/516#issuecomment-454767020, specifically:

* The `Sass` filter is upgraded to use the new dart Sass compiler, and all incompatible options are removed
* A new `RubySass` filter is created, to preserve use of the legacy ruby Sass compiler

I have tried to make the documentation and testing sensible for the new compiler, but I am happy to make further changes if that will help.

This will require a major version bump as it is a breaking change.