### PR TITLE
Use the safe load method in the YAML loader to avoid a warning

### DIFF
--- a/src/webassets/loaders.py
+++ b/src/webassets/loaders.py
@@ -159,7 +159,7 @@ class YAMLLoader(object):
         # as absolute paths" option?
         f, _ = self._open()
         try:
-            obj = self.yaml.load(f) or {}
+            obj = self.yaml.safe_load(f) or {}
             return self._get_bundles(obj, environment)
         finally:
             f.close()
@@ -198,7 +198,7 @@ class YAMLLoader(object):
         """
         f, filename = self._open()
         try:
-            obj = self.yaml.load(f) or {}
+            obj = self.yaml.safe_load(f) or {}
 
             env = Environment()
 


### PR DESCRIPTION
The YAML loader is currently using the `yaml.load()` method without defining a loader, which is [deprecated](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation) and causes a warning to appear:

```
YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  obj = self.yaml.load(f) or {}
```

This patch updates the call to use `yaml.safe_load()` which is a shortcut method to use the `SafeLoader` class.

Fixes #517
