### PR TITLE
Use is_alive instead of isAlive for Python 3.9 compatibility.

### DIFF
--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -192,7 +192,7 @@ class TestWatchMixin(object):
 
     def stop_watching(self):
         """Stop the watch command thread."""
-        assert self.t.isAlive() # If it has already ended, something is wrong
+        assert self.t.is_alive() # If it has already ended, something is wrong
         self.stopped = True
         self.t.join(1)
 


### PR DESCRIPTION
Fixes #528 