### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -121,7 +121,7 @@ In 0.8
   only works on the level of :meth:`Bundle.urls`. The new behaviour is more
   consistent, makes more sense, and simplifies the code.
 
-  The main backwards-incompatiblity caused by this is that when
+  The main backwards-incompatibility caused by this is that when
   ``environment.auto_build=False``, and you are calling ``bundle.build()``
   without specifying an explicit ``force`` argument, it used to be the case
   that ``force=True`` was assumed, i.e. the bundle was built without looking

--- a/src/webassets/filter/__init__.py
+++ b/src/webassets/filter/__init__.py
@@ -460,7 +460,7 @@ class ExternalTool(six.with_metaclass(ExternalToolMetaclass, Filter)):
     def subprocess(cls, argv, out, data=None, cwd=None):
         """Execute the commandline given by the list in ``argv``.
 
-        If a byestring is given via ``data``, it is piped into data.
+        If a bytestring is given via ``data``, it is piped into data.
 
         If ``cwd`` is not None, the process will be executed in that directory.
 

--- a/tests/test_bundle_various.py
+++ b/tests/test_bundle_various.py
@@ -496,7 +496,7 @@ class TestGlobbing(TempEnvironmentHelper):
         bundle.resolve_contents()
 
     def test_non_pattern_missing_files(self):
-        """Ensure that if we specify a non-existant file, it will still
+        """Ensure that if we specify a non-existent file, it will still
         be returned in the debug urls(), and build() will raise the IOError
         rather than the globbing failing and the bundle being empty
         """


### PR DESCRIPTION
There are small typos in:
- docs/upgrading.rst
- src/webassets/filter/__init__.py
- tests/test_bundle_various.py

Fixes:
- Should read `incompatibility` rather than `incompatiblity`.
- Should read `existent` rather than `existant`.
- Should read `bytestring` rather than `byestring`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md