### PR TITLE
Support use on systems enforcing FIPS compliance.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/src/webassets/utils.py
+++ b/src/webassets/utils.py
@@ -16,8 +16,15 @@ import base64
 
 if sys.version_info >= (2, 5):
     import hashlib
-    from functools import partial
-    md5_constructor = partial(hashlib.md5, usedforsecurity=False)
+    try:
+        from functools import partial
+        # Include the usedforsecurity parameter so the call will
+        # succeed on systems that enforce compliance with the 
+        # Federal Information Processing Standard (FIPS) and thus
+        # don't allow md5 for encryption.
+        md5_constructor = partial(hashlib.md5,usedforsecurity=False)
+    except (ImportError,TypeError):
+        md5_constructor = hashlib.md5
 else:
     import md5
     md5_constructor = md5.new

--- a/src/webassets/utils.py
+++ b/src/webassets/utils.py
@@ -16,7 +16,8 @@ import base64
 
 if sys.version_info >= (2, 5):
     import hashlib
-    md5_constructor = hashlib.md5
+    from functools import partial
+    md5_constructor = partial(hashlib.md5, usedforsecurity=False)
 else:
     import md5
     md5_constructor = md5.new


### PR DESCRIPTION
The Federal Information Processing Standards (FIPS) do not allow using the md5 algorithm for encryption since it is considered too weak. The hashlib implementation of md5 provided a workaround permitting continued use of the fast md5 algorithm by explicitly noting the use was not for security purposes. The changes here try using that workaround, and fall back to failing on systems enforcing FIPS.